### PR TITLE
Use source instead of .

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In order to run GraphSpace, please install sqlite3 and both the Python runtime a
 1. Download the GraphSpace code by running `git clone https://github.com/Murali-group/GraphSpace.git` or by downloading the latest release: https://github.com/Murali-group/GraphSpace/releases.
 2. Visit the GraphSpace directory: `cd GraphSpace`
 3. Modify the `gs-setup.sh` file by populating the `EMAIL_HOST_USER` and `EMAIL_HOST_PASSWORD` fields.  GraphSpace uses `EMAIL_HOST_USER` as the email address through which GraphSpace sends emails to its users.
-4. Propogate changes to these variables in `gs-setup.sh` file to the environment: `. gs-setup.sh`.  Please run `. gs-setup.sh` and not `./gs-setup.sh` as this will not propogate the changes to the environment properly. *This step may require sudo privileges*
+4. Propogate changes to these variables in `gs-setup.sh` file to the environment: `source gs-setup.sh`.  Please run `. gs-setup.sh` and not `./gs-setup.sh` as this will not propogate the changes to the environment properly. *This step may require sudo privileges*
 5. Finally, start the GraphSpace server: `python manage.py runserver`
 6. Visit `http://localhost:8080` and enjoy using GraphSpace!
 
@@ -29,7 +29,7 @@ This section describes the steps required to launch GraphSpace on a server that 
 1. Visit the graphspace directory: `cd GraphSpace/graphspace`
 3. In a text editor, open the file `gs-setup.sh`
 4. Set `DEBUG=False` and `TEMPLATE_DEBUG=False`
-5. Propogate those changes to the environment: `. gs-setup.sh`
+5. Propogate those changes to the environment: `source gs-setup.sh`
 6. Visit the `apache2` directory: `cd /path_to/apache2`. An example of the full path to this directory is `/etc/apache2`.
 7. Navigate to the `sites-enabled` directory: `cd sites-enabled`
 8. Create a file called `graphspace.conf`


### PR DESCRIPTION
`source script.sh` is an alias for `. script.sh` (source command). This won't work on OS X as `.` is not available on it (by default)