### PR TITLE
[issue_132] Adds authentication check in deleteGraph view

### DIFF
--- a/graphs/views.py
+++ b/graphs/views.py
@@ -1078,14 +1078,25 @@ def deleteGraph(request):
         :return JSON: {"Delete": <message>}
     '''
     if request.method == 'POST':
-        user_id = request.POST['uid']
-        graphname = request.POST['gid']
-        jsonData = db.get_graph_json(user_id, graphname)
-        if jsonData != None:
-            db.delete_graph(request.POST['uid'], request.POST['gid'])
-            return HttpResponse(json.dumps(db.sendMessage(200, "Successfully deleted " + graphname + " owned by " + user_id + '.'), indent=4, separators=(',', ': ')), content_type="application/json")
+        uid = request.POST['uid']
+        gid = request.POST['gid']
+
+        # Check if the user is authenticated
+        if request.session.get('uid') == None:
+            return HttpResponse(json.dumps(db.throwError(401, "You are not allowed to delete this graph"), indent=4, separators=(',', ': ')), content_type="application/json")
+
+        # if the user owns the graph only then allow him to delete it
+        graph_info = db.getGraphInfo(uid,gid)
+        if graph_info == None:
+            return HttpResponse(json.dumps(db.throwError(404, "You do not own any such Graph."), indent=4, separators=(',', ': ')), content_type="application/json")
         else:
-            return HttpResponse(json.dumps(db.throwError(404, "No Such Graph Exists."), indent=4, separators=(',', ': ')), content_type="application/json")
+
+            jsonData = db.get_graph_json(uid, gid)
+            if jsonData != None:
+                db.delete_graph(uid, gid)
+                return HttpResponse(json.dumps(db.sendMessage(200, "Successfully deleted " + gid + " owned by " + uid + '.'), indent=4, separators=(',', ': ')), content_type="application/json")
+            else:
+                return HttpResponse(json.dumps(db.throwError(404, "You do not own any such Graph."), indent=4, separators=(',', ': ')), content_type="application/json")
 
 def delete_group_through_ui(request):
     '''


### PR DESCRIPTION
Only the owner is allowed to delete the graph. While working on this I realized that according to the current schema there's no unique id for a graph and user_id and graph_id when used together act as primary key. The issue with this is that there's no way of raising an error that "You do not have permission to delete this graph" since we can't simply search by a graph_id we need to search by user_id and graph_id together, now since the current authenticated user does not own that graph for him 'graph_info' is None. In this case we should check whether any such graph exists or not and if it does we should raise an error saying you do not have permissions to delete this graph and if it does not exists we can simply raise an error that there's no such graph. Which is not possible currently since there's no way to check whether the graph(owned by someone else) exists or not.

Simple solution for this can be generating random unique strings for graph ids and using it as primary key for the graph. This can be used in other administrative actions as well and will help in raising better errors and will simplify the schema as well.
@tmmurali @DSin52 Your thoughts on this?