### PR TITLE
[Fixes #117] Removes persistence of search

### DIFF
--- a/graphs/static/graphs/js/view_graph.js
+++ b/graphs/static/graphs/js/view_graph.js
@@ -516,8 +516,9 @@ $(document).ready(function() {
      $("#search_button").click(function (e) {
       e.preventDefault();
       if ($("#search").val().length > 0) {
-        // window.cy.elements().removeCss();
-        searchValues($('input[name=match]:checked').val(), $("#search").val());
+        var search_val = $("#search").val();
+        clearSearchTerms();
+        searchValues($('input[name=match]:checked').val(), search_val);
       }
      });
 


### PR DESCRIPTION
This works similar to when you click on 'Clear all search terms' button in which case step filters do persist.
@tmmurali @DSin52 