### PR TITLE
Fix typo, background-opacity instead of border-opacity

### DIFF
--- a/graphs/static/graphs/js/view_graph.js
+++ b/graphs/static/graphs/js/view_graph.js
@@ -70,7 +70,7 @@ $(document).ready(function() {
                 'background-blacken': 'data(background_blacken)'
             })
             .selector('node[background_opacity]').css({
-                'border-opacity': 'data(background_opacity)'
+                'background-opacity': 'data(background_opacity)'
             })
             .selector('node[border_width]').css({
                 'border-width': 'data(border_width)'

--- a/graphs/static/graphs/js/view_graph_expert.js
+++ b/graphs/static/graphs/js/view_graph_expert.js
@@ -71,7 +71,7 @@ $(document).ready(function() {
                 'background-blacken': 'data(background_blacken)'
             })
             .selector('node[background_opacity]').css({
-                'border-opacity': 'data(background_opacity)'
+                'background-opacity': 'data(background_opacity)'
             })
             .selector('node[border_width]').css({
                 'border-width': 'data(border_width)'


### PR DESCRIPTION
The background-opacity node property was wrongly referenced by border-opacity. Fixed it

@DSin52 