### PR TITLE
Validate graph properties fix

### DIFF
--- a/graphspace_interface/graphspace_interface.py
+++ b/graphspace_interface/graphspace_interface.py
@@ -88,9 +88,9 @@ DEFAULT_METADATA = {'description':'','tags':[],'title':''}
 
 ## JSON VALIDATOR FUNCTIONS #########################################
 
-def validate_json(G):
+def validate_network_properties(G):
     """
-    Validates JSON to see if all properties are consistent with API.
+    Validates the NetworkX nodes and edges to see if all properties are consistent with API.
 
     @param G: NetworkX object.
     """
@@ -110,39 +110,41 @@ def validate_edge_properties(G):
 
     # Go through all edges to verify if edges contain valid properties
     # recognized by CytoscapeJS
-    for edge_id in G.edge:
+    for source in G.edge:
+        for target in G.edge[source]:
+            edge_id = str((source, target))
 
-        # If edge is directed, it must have a target_arrow_shape
-        if "directed" in G.edge[edge_id] and G.edge[edge_id] == "true":
-            if "target_arrow_shape" not in G.edge[edge_id]:
-                print "Edge: ", edge_id, "must have a target_arrow_shape property if directed is true"
+            # If edge is directed, it must have a target_arrow_shape
+            if "directed" in G.edge[source][target] and G.edge[source][target] == "true":
+                if "target_arrow_shape" not in G.edge[source][target]:
+                    print "Edge: ", edge_id, "must have a target_arrow_shape property if directed is true"
 
-        if "source_arrow_shape" in G.edge[edge_id]:
-            find_property_in_array("Edge", edge_id, "source_arrow_shape", G.edge[edge_id]["source_arrow_shape"], ALLOWED_ARROW_SHAPES)
+            if "source_arrow_shape" in G.edge[source][target]:
+                find_property_in_array("Edge", edge_id, "source_arrow_shape", G.edge[source][target]["source_arrow_shape"], ALLOWED_ARROW_SHAPES)
 
-        if "mid_source_arrow_shape" in G.edge[edge_id]:
-            find_property_in_array("Edge", edge_id, "mid_source_arrow_shape", G.edge[edge_id]["mid_source_arrow_shape"], ALLOWED_ARROW_SHAPES)
+            if "mid_source_arrow_shape" in G.edge[source][target]:
+                find_property_in_array("Edge", edge_id, "mid_source_arrow_shape", G.edge[source][target]["mid_source_arrow_shape"], ALLOWED_ARROW_SHAPES)
 
-        if "target_arrow_shape" in G.edge[edge_id]:
-            find_property_in_array("Edge", edge_id, "target_arrow_shape", G.edge[edge_id]["target_arrow_shape"], ALLOWED_ARROW_SHAPES)
+            if "target_arrow_shape" in G.edge[source][target]:
+                find_property_in_array("Edge", edge_id, "target_arrow_shape", G.edge[source][target]["target_arrow_shape"], ALLOWED_ARROW_SHAPES)
 
-        if "mid_target_arrow_shape" in G.edge[edge_id]:
-            find_property_in_array("Edge", edge_id, "mid_target_arrow_shape", G.edge[edge_id]["mid_target_arrow_shape"], ALLOWED_ARROW_SHAPES)
+            if "mid_target_arrow_shape" in G.edge[source][target]:
+                find_property_in_array("Edge", edge_id, "mid_target_arrow_shape", G.edge[source][target]["mid_target_arrow_shape"], ALLOWED_ARROW_SHAPES)
 
-        if "line_style" in G.edge[edge_id]:
-            find_property_in_array("Edge", edge_id, "line_style", G.edge[edge_id]["line_style"], ALLOWED_EDGE_STYLES)
+            if "line_style" in G.edge[source][target]:
+                find_property_in_array("Edge", edge_id, "line_style", G.edge[source][target]["line_style"], ALLOWED_EDGE_STYLES)
 
-        if "source_arrow_fill" in G.edge[edge_id]:
-            find_property_in_array("Edge", edge_id, "source_arrow_fill", G.edge[edge_id]["source_arrow_fill"], ALLOWED_ARROW_FILL)
+            if "source_arrow_fill" in G.edge[source][target]:
+                find_property_in_array("Edge", edge_id, "source_arrow_fill", G.edge[source][target]["source_arrow_fill"], ALLOWED_ARROW_FILL)
 
-        if "mid_source_arrow_fill" in G.edge[edge_id]:
-            find_property_in_array("Edge", edge_id, "mid_source_arrow_fill", G.edge[edge_id]["mid_source_arrow_fill"], ALLOWED_ARROW_FILL)
+            if "mid_source_arrow_fill" in G.edge[source][target]:
+                find_property_in_array("Edge", edge_id, "mid_source_arrow_fill", G.edge[source][target]["mid_source_arrow_fill"], ALLOWED_ARROW_FILL)
 
-        if "target_arrow_fill" in G.edge[edge_id]:
-            find_property_in_array("Edge", edge_id, "target_arrow_fill", G.edge[edge_id]["target_arrow_fill"], ALLOWED_ARROW_FILL)
+            if "target_arrow_fill" in G.edge[source][target]:
+                find_property_in_array("Edge", edge_id, "target_arrow_fill", G.edge[source][target]["target_arrow_fill"], ALLOWED_ARROW_FILL)
 
-        if "mid_target_arrow_fill" in G.edge[edge_id]:
-            find_property_in_array("Edge", edge_id, "mid_target_arrow_fill", G.edge[edge_id]["mid_target_arrow_fill"], ALLOWED_ARROW_FILL)
+            if "mid_target_arrow_fill" in G.edge[source][target]:
+                find_property_in_array("Edge", edge_id, "mid_target_arrow_fill", G.edge[source][target]["mid_target_arrow_fill"], ALLOWED_ARROW_FILL)
 
 def validate_node_properties(G):
     """
@@ -788,6 +790,9 @@ def postGraph(G,graphid,outfile,user,password,metadata=None,logfile=None):
     else:
         logout = None
         
+    # validate the NetworkX object to see if all properties are consistent with API.
+    validate_network_properties(G)
+
     # convert NetworkX object to a serialized_graph
     convertNXToJSON(G,outfile,metadata)
 


### PR DESCRIPTION
Fixes issue #193.

From commit message: Renamed validate_json() to validate_graph_properties(). Fixed validate_edge_properties() to correctly validate each edges properties. Added a call to validate_graph_properties() in the function postGraph() before the call to convertNXToJSON(). This is so the code will automatically check the properties before trying to post.

I tested adding an invalid attribute to the edge ("TORC1", "TORC1_Sch9_Sch9P") and the code exits as expected with the following error message:
`Exception: Edge with ID: "('TORC1', 'TORC1_Sch9_Sch9P')" contains illegal source_arrow_shape: "test".  Accepted values for this property are: ['tee', 'triangle', 'triangle-tee', 'triangle-backcurve', 'square', 'circle', 'diamond', 'none'].`

This code is working, but isn't complete yet. For example: setting an edge's color to an empty list causes the 'post' curl command to return this cryptic message:

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 webmaster@localhost to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.7 (Ubuntu) Server at graphspace.org Port 80</address>
</body></html>
```

GraphSpace should return a more helpful status code like 'JSON formatted incorrectly'. Not sure if we want to update the python graphspace_interface.py to handle cases like these. 
