### PR TITLE
Migrated from sqlite database to postgres database (#205)

### DIFF
--- a/graphs/models.py
+++ b/graphs/models.py
@@ -10,15 +10,13 @@ There are two differences:
        ex. 'id' for user table would be 'user_id'
 '''
 
-from sqlalchemy import Column, Integer, String, ForeignKey, Table, Index, ForeignKeyConstraint
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, backref
-from sqlalchemy.types import TIMESTAMP
-from django.db import models
-from django.conf import settings
+from sqlalchemy import Column, Integer, String, ForeignKey, Index, ForeignKeyConstraint
 from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+from sqlalchemy.types import TIMESTAMP
 
-import bcrypt
+from django.conf import settings
 
 # Construct a base class for declarative class definitions.
 # The new base class will be given a metaclass that produces appropriate Table objects
@@ -36,7 +34,7 @@ Base = declarative_base()
 # primary key. 'user_id' is a foreign key referring to the 'user_id' column in 
 # the 'user' table. 'group_id' is a foreign key referring to the 'group_id' column 
 # in the 'group' table.
-        
+
 # For each graph, this table stores the groups that the graph belongs to. 
 # Note that a graph may belong to multiple groups. 
 
@@ -47,48 +45,6 @@ Base = declarative_base()
 #=================== End of Junction Tables ===================
 
 # ================== Table Definitions ===================
-class GroupToUser(Base):
-    '''The class representing the schema of the group_to_user table.'''
-    __tablename__ = 'group_to_user'
-
-    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
-    group_id = Column(String, ForeignKey('group.group_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
-    group_owner = Column(String, ForeignKey('group.owner_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
-       
-class Feedback(Base):
-    __tablename__ = 'feedback'
-
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    graph_id = Column(String, ForeignKey('graph.graph_id', ondelete="CASCADE", onupdate="CASCADE"))
-    user_id = Column(String, ForeignKey('graph.user_id', ondelete="CASCADE", onupdate="CASCADE"))
-    layout_id = Column(String, ForeignKey('layout.layout_id', ondelete="CASCADE", onupdate="CASCADE"))
-    text = Column(String, nullable = False)
-    created = Column(TIMESTAMP, nullable = False)
-
-class GroupToGraph(Base):
-    '''The class representing the schema of the group_to_graph table.'''
-    __tablename__ = 'group_to_graph'
-
-    group_id = Column(String, ForeignKey('group.group_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
-    group_owner = Column(String, ForeignKey('group.owner_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
-    graph_id = Column(String, ForeignKey('graph.graph_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
-    user_id = Column(String, ForeignKey('graph.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
-    modified = Column(TIMESTAMP, nullable = False)
-
-class GraphToTag(Base):
-    '''The class representing the schema of the graph_to_tag table.'''
-    __tablename__ = 'graph_to_tag'
-
-    graph_id = Column(String, ForeignKey('graph.graph_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
-    user_id = Column(String, ForeignKey('graph.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
-    tag_id = Column(String, ForeignKey('graph_tag.tag_id'), primary_key=True)
-
-class TaskCode(Base):
-    '''The class representing the schema of the task_code table.'''
-    __tablename__ = 'task_code'
-    hit_id = Column(String, ForeignKey('task.hit_id', ondelete="CASCADE", onupdate="CASCADE"))
-    code = Column(String, primary_key = True)
-    created = Column(TIMESTAMP, nullable = False)
 
 class User(Base):
     '''The class representing the schema of the user table.'''
@@ -100,42 +56,44 @@ class User(Base):
 
     # one to many relationships. TODO: add cascades
     # at most one user can create a graph layout
-    layouts = relationship("Layout")
+    layouts = relationship("Layout", foreign_keys="[Layout.owner_id]", back_populates="owner", cascade="all, delete-orphan")
     # each group has at most one user who created it. See the owner_id column in the 'Group' class.
-    owned_groups = relationship("Group")
+    owned_groups = relationship("Group", cascade="all, delete-orphan")
     # each graph has at most one creator.
-    graphs = relationship("Graph") 
-    # ??? 
+    graphs = relationship("Graph", cascade="all, delete-orphan")
+    # ???
     password_reset = relationship("PasswordReset")
-       
-# TODO: change name to Group here and in the db.
+
+
 class Group(Base):
     __tablename__ = 'group'
-    
+
     group_id = Column(String, primary_key = True)
     # TODO: describe the difference bewteen group_id and name.
     name = Column(String, nullable = False)
-    # Each group has one owner, who must be in the user table. The foreign key 
+    # Each group has one owner, who must be in the user table. The foreign key
     # statement corresponds to the owned_groups relationship in the 'User' class.
     owner_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False, primary_key = True)
     description = Column(String, nullable = False)
 
     # This line creates the many-to-many relationship between the User class and the i
-    # Group class through the group_to_user junction table. Specifically, 
-    # it links the 'User' class to the current class using the group_to_user junction 
-    # table; this is a many to one relationship from 'User' to 'group_to_user'. 
-    # The backref argument establishes the many to one relationship from 'Group' 
-    # to 'group_to_user'. An equivalent way to link the two classes is to instead 
+    # Group class through the group_to_user junction table. Specifically,
+    # it links the 'User' class to the current class using the group_to_user junction
+    # table; this is a many to one relationship from 'User' to 'group_to_user'.
+    # The backref argument establishes the many to one relationship from 'Group'
+    # to 'group_to_user'. An equivalent way to link the two classes is to instead
     # add the following line to User:
     # groups = relationship('Group', secondary=group_to_user, backref='user')
     # users = relationship('User', backref='group')
     # # specifies many-to-many relationship with Graph table
     # graphs = relationship('Graph', backref='group')
 
+
+
 class Graph(Base):
     __tablename__ = 'graph'
 
-    # The graph_id and user_id together specify the primary key.     
+    # The graph_id and user_id together specify the primary key.
     graph_id = Column(String, primary_key = True) #id
     user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key = True)
     json = Column(String, nullable = False)
@@ -143,7 +101,7 @@ class Graph(Base):
     modified = Column(TIMESTAMP, nullable = False)
     public = Column(Integer, nullable = True)
     shared_with_groups = Column(Integer, nullable = True)
-    default_layout_id = Column(String, nullable = True)
+    default_layout_id = Column(Integer, ForeignKey('layout.layout_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = True)
 
     # specify one to many relationships
     # layouts = relationship("Layout")
@@ -151,50 +109,11 @@ class Graph(Base):
     # nodes = relationship("Node")
 
     # groups = relationship("Group", backref='graph')
-    
+
     #specify many to many relationship with GraphTag
     # tags = relationship("GraphTag", secondary=graph_to_tag, backref='graph')
 
-class Task(Base):
-    '''
-        Table that represents the task table.
-    '''
-    __tablename__ = 'task'
 
-    task_id = Column(Integer, autoincrement=True, primary_key=True)
-    task_owner = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False)
-    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False)
-    graph_id = Column(String, ForeignKey('graph.graph_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False)
-    layout_id = Column(String, ForeignKey('layout.layout_id', ondelete="CASCADE", onupdate="CASCADE"))
-    created = Column(TIMESTAMP, nullable = False)
-    hit_id=Column(String, nullable=False)
-    worker_id=Column(String, nullable=False)
-    submitted=Column(Integer, nullable=True)
-    task_type=Column(String, nullable=False)
-
-class GraphTag(Base):
-    '''
-        Table of tags that are assigned to each graph to categorize them.
-    '''
-    __tablename__ = 'graph_tag'
-    tag_id = Column(String, primary_key = True) #id
-
-class Feature(Base):
-    '''
-        Table that holds all the features.
-    '''
-    __tablename__ = 'feature'
-
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"))
-    graph_id = Column(String, ForeignKey('graph.graph_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = True)
-    layout_id = Column(String, ForeignKey('layout.layout_id', ondelete="CASCADE", onupdate="CASCADE"))
-    created = Column(TIMESTAMP, nullable = False)
-    distance_vector = Column(String, nullable = True)
-    pairwise_vector = Column(String, nullable = True)
-    num_changes = Column(Integer, nullable = False)
-    time_spent = Column(Integer, nullable = False)
-    events = Column(String, nullable = False)
 
 class Layout(Base):
     '''
@@ -208,19 +127,19 @@ class Layout(Base):
     # layout in GraphSpace.
     layout_name = Column(String, nullable = False)
 
-    # The id of the user who created the layout. The foreign key constraint ensures 
-    # this person is present in the 'user' table. Not that owner_id need not be the 
-    # same as user_id since (graph_id, user_id) uniquely identify the graph. 
-    # In other words, the owner_id can be the person other than the one who created 
-    # the graph (user_id). An implicit rule is that owner_id must belong to some 
-    # group that this graph belongs to. However, the database does not enforce this 
-    # constraint explicitly. 
+    # The id of the user who created the layout. The foreign key constraint ensures
+    # this person is present in the 'user' table. Not that owner_id need not be the
+    # same as user_id since (graph_id, user_id) uniquely identify the graph.
+    # In other words, the owner_id can be the person other than the one who created
+    # the graph (user_id). An implicit rule is that owner_id must belong to some
+    # group that this graph belongs to. However, the database does not enforce this
+    # constraint explicitly.
     # TODO: Add a database constraint that checks this rule.
     owner_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False)
     # id of the graph that the layout is for
     graph_id = Column(String, nullable = False)
     # id of the user who owns the graph specified by graph_id
-    user_id = Column(String, nullable = False)
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False)
     # graph layout data in JSON format
     json = Column(String, nullable = False)
     public = Column(Integer, nullable = True)
@@ -233,6 +152,112 @@ class Layout(Base):
     # SQLAlchemy's way of creating a multi-column foreign key constraint.
     __table_args__ = (ForeignKeyConstraint([graph_id, user_id], [Graph.graph_id, Graph.user_id], ondelete="CASCADE", onupdate="CASCADE"), {})
 
+    owner = relationship("User", foreign_keys=[owner_id], back_populates="layouts", uselist=False)
+
+class GroupToUser(Base):
+    '''The class representing the schema of the group_to_user table.'''
+    __tablename__ = 'group_to_user'
+
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
+    group_id = Column(String, primary_key=True)
+    group_owner = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
+
+    __table_args__ = (ForeignKeyConstraint([group_id, group_owner], [Group.group_id, Group.owner_id], ondelete="CASCADE", onupdate="CASCADE"), {})
+
+
+class Feedback(Base):
+    __tablename__ = 'feedback'
+
+    id = Column(Integer, autoincrement=True, primary_key=True)
+    graph_id = Column(String)
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"))
+    layout_id = Column(Integer, ForeignKey('layout.layout_id', ondelete="CASCADE", onupdate="CASCADE"))
+    text = Column(String, nullable = False)
+    created = Column(TIMESTAMP, nullable = False)
+
+    __table_args__ = (ForeignKeyConstraint([graph_id, user_id], [Graph.graph_id, Graph.user_id], ondelete="CASCADE", onupdate="CASCADE"), {})
+
+class GroupToGraph(Base):
+    '''The class representing the schema of the group_to_graph table.'''
+    __tablename__ = 'group_to_graph'
+
+    group_id = Column(String, primary_key=True)
+    group_owner = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
+    graph_id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
+    modified = Column(TIMESTAMP, nullable = False)
+
+    __table_args__ = (ForeignKeyConstraint([graph_id, user_id], [Graph.graph_id, Graph.user_id], ondelete="CASCADE", onupdate="CASCADE"),
+                      ForeignKeyConstraint([group_id, group_owner], [Group.group_id, Group.owner_id], ondelete="CASCADE", onupdate="CASCADE"), {})
+
+class GraphToTag(Base):
+    '''The class representing the schema of the graph_to_tag table.'''
+    __tablename__ = 'graph_to_tag'
+
+    graph_id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
+    tag_id = Column(String, ForeignKey('graph_tag.tag_id'), primary_key=True)
+
+    __table_args__ = (ForeignKeyConstraint([graph_id, user_id], [Graph.graph_id, Graph.user_id], ondelete="CASCADE", onupdate="CASCADE"), {})
+
+
+class TaskCode(Base):
+    '''The class representing the schema of the task_code table.'''
+    __tablename__ = 'task_code'
+    hit_id = Column(String, ForeignKey('task.hit_id', ondelete="CASCADE", onupdate="CASCADE"))
+    code = Column(String, primary_key = True)
+    created = Column(TIMESTAMP, nullable = False)
+
+
+
+class Task(Base):
+    '''
+        Table that represents the task table.
+    '''
+    __tablename__ = 'task'
+
+    task_id = Column(Integer, autoincrement=True, primary_key=True)
+    task_owner = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False)
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False)
+    graph_id = Column(String, nullable = False)
+    layout_id = Column(Integer, ForeignKey('layout.layout_id', ondelete="CASCADE", onupdate="CASCADE"))
+    created = Column(TIMESTAMP, nullable = False)
+    hit_id=Column(String, nullable=False)
+    worker_id=Column(String, nullable=False)
+    submitted=Column(Integer, nullable=True)
+    task_type=Column(String, nullable=False)
+
+    __table_args__ = (ForeignKeyConstraint([graph_id, user_id], [Graph.graph_id, Graph.user_id], ondelete="CASCADE", onupdate="CASCADE"), {})
+
+
+class GraphTag(Base):
+    '''
+        Table of tags that are assigned to each graph to categorize them.
+    '''
+    __tablename__ = 'graph_tag'
+    tag_id = Column(String, primary_key = True) #id
+
+
+class Feature(Base):
+    '''
+        Table that holds all the features.
+    '''
+    __tablename__ = 'feature'
+
+    id = Column(Integer, autoincrement=True, primary_key=True)
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"))
+    graph_id = Column(String, nullable = True)
+    layout_id = Column(Integer, ForeignKey('layout.layout_id', ondelete="CASCADE", onupdate="CASCADE"))
+    created = Column(TIMESTAMP, nullable = False)
+    distance_vector = Column(String, nullable = True)
+    pairwise_vector = Column(String, nullable = True)
+    num_changes = Column(Integer, nullable = False)
+    time_spent = Column(Integer, nullable = False)
+    events = Column(String, nullable = False)
+
+    __table_args__ = (ForeignKeyConstraint([graph_id, user_id], [Graph.graph_id, Graph.user_id], ondelete="CASCADE", onupdate="CASCADE"), {})
+
+
 class LayoutStatus(Base):
     '''
        Table of layout acceptances/rejections.
@@ -240,9 +265,9 @@ class LayoutStatus(Base):
     __tablename__ = 'layout_status'
 
     id = Column(Integer, autoincrement=True, primary_key=True)
-    graph_id = Column(String, ForeignKey('graph.graph_id', ondelete="CASCADE", onupdate="CASCADE"))
-    user_id = Column(String, ForeignKey('graph.user_id', ondelete="CASCADE", onupdate="CASCADE"))
-    layout_id = Column(Integer, nullable = False)
+    graph_id = Column(String)
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"))
+    layout_id = Column(Integer, ForeignKey('layout.layout_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False)
     triangle_rating = Column(Integer, nullable = False)
     rectangle_rating = Column(Integer, nullable = False)
     shape_rating = Column(Integer, nullable = False)
@@ -250,9 +275,11 @@ class LayoutStatus(Base):
     created = Column(TIMESTAMP, nullable = False)
     submitted_by = Column(String, nullable = True)
 
+    __table_args__ = (ForeignKeyConstraint([graph_id, user_id], [Graph.graph_id, Graph.user_id], ondelete="CASCADE", onupdate="CASCADE"), {})
+
 class Node(Base):
     '''
-        Table of nodes used in graphs. Same node can be in many graphs, but they are 
+        Table of nodes used in graphs. Same node can be in many graphs, but they are
         considered to be distinct.
     '''
     __tablename__ = 'node'
@@ -260,9 +287,9 @@ class Node(Base):
     # The primary key contains three columns: node_id, graph_id, and user_id. The same node may appear in different graphs but we consider them to be distinct.
     node_id = Column(String, primary_key = True)
     label = Column(String, nullable = False)
-    user_id = Column(String, primary_key = True)
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), primary_key = True)
     graph_id = Column(String, primary_key = True)
-    modified = Column(TIMESTAMP, primary_key = True)
+    modified = Column(TIMESTAMP, primary_key = False)
 
     # Foregin key contraint to idientify the graph that this node belong to
     __table_args__ = (ForeignKeyConstraint([user_id, graph_id], [Graph.user_id, Graph.graph_id], ondelete="CASCADE", onupdate="CASCADE"), {})
@@ -290,7 +317,7 @@ class Edge(Base):
     # 3 column primary keys are used to determine which two nodes that this edge connect.
     # each edge connects a head node to a tail node.
     # head node
-    user_id = Column(String, nullable = False)
+    user_id = Column(String, ForeignKey('user.user_id', ondelete="CASCADE", onupdate="CASCADE"), nullable = False)
     graph_id = Column(String, nullable = False)
     head_node_id = Column(String, nullable = False)
     # head_node_label column was added to speed up the similar terms search query on edges. The lookup on two tables was taking too much time.
@@ -309,7 +336,7 @@ class Edge(Base):
     directed = Column(Integer, nullable = True)
 
     id = Column(Integer, autoincrement=True, primary_key=True)
-    
+
     # Foreign key contraints to determine each node.
     __table_args__ = (
             ForeignKeyConstraint([user_id, graph_id, head_node_id], [Node.user_id, Node.graph_id, Node.node_id], ondelete="CASCADE", onupdate="CASCADE"),
@@ -319,6 +346,7 @@ class Edge(Base):
 #Create indices
 Index('graph_public_idx', Graph.public)
 Index('graph_owner_idx', Graph.user_id)
+Index('graph_idx_graph_id', Graph.graph_id)
 # Table: group. Columns: owner_id
 Index('group_idx_owner_id_group_id', Group.owner_id, Group.group_id)
 # Table: graph. Columns: user_id
@@ -349,15 +377,20 @@ Index('group_to_user_idx_user_id', GroupToUser.user_id)
 #Index('layout_idx_owner_id', Layout.owner_id)
 # Table: node. Columns: graph_id, user_id
 Index('node_idx_graph_id_user_id', Node.graph_id, Node.user_id, Node.node_id, Node.label)
-Index('node_index_label_graph_id', Node.label)
-Index('node_index_node_id_graph_id', Node.node_id)
+Index('node_index_label', Node.label)
+Index('node_index_label_graph_id', Node.label, Node.graph_id)
+Index('node_index_node_id', Node.node_id)
+Index('node_index_node_id_graph_id', Node.node_id, Node.graph_id)
 
 Index('edge_idx_head_id_tail_id', Edge.head_node_id, Edge.tail_node_id)
 Index('edge_idx_head_label_tail_label', Edge.head_node_label, Edge.tail_node_label)
 # Create an engine that stores data in the local directory's
 # sqlalchemy_example.db file.
-engine = create_engine(settings.DATABASE_LOCATION, echo=False)
- 
+config = settings.DATABASES['default']
+engine = create_engine(''.join(
+			['postgresql://', config['USER'], ':', config['PASSWORD'], '@', config['HOST'], ':', config['PORT'], '/', config['NAME']]), echo=False)
+
+#
 # Create all tables in the engine. This is equivalent to "Create Table"
 # statements in raw SQL.
 Base.metadata.create_all(engine)

--- a/graphs/templates/graphs/help_programmers.html
+++ b/graphs/templates/graphs/help_programmers.html
@@ -57,6 +57,7 @@ Below is a list of the different REST API calls.
 <li><a href="#update_graph">Update graph</a></li>
 <li><a href="#remove_graph">Remove graph</a></li>
 <li><a href="#get_user_graphs">Get user graphs</a></li>
+<li><a href="#get_all_graphs">Get all graphs</a></li>
 <li><a href="#make_graph_public">Make graph public</a></li>
 <li><a href="#make_graph_private">Make graph private</a></li>
 </ul>
@@ -71,6 +72,14 @@ Below is a list of the different REST API calls.
 <li><a href="#remove_user_from_group">Remove user from group</a></li>
 <li><a href="#share_graph">Share a graph with a group</a></li>
 <li><a href="#unshare_graph">Unshare a graph with a group</a></li>
+</ul>
+</li>
+<li><h4><a href="#layouts">Layout</a></h4>
+<ul>
+<li><a href="#get_graph_layouts">Get all layouts for a graph.</a></li>
+<li><a href="#get_layout">Get layout</a></li>
+<li><a href="#create_layout">Create layout</a></li>
+<li><a href="#update_layout">Update layout</a></li>
 </ul>
 </li>
 <li><h4><a href="#tags">Tags</a></h4>
@@ -588,6 +597,52 @@ Example response:
 }
 </pre>
 
+
+<h3 style="padding-top: 50px; margin-top: -40px;" id="get_all_graphs">Get all graphs</h3>
+
+Get a summary of all graphs belonging to the user making this request and public graphs (viewable to all users of GS). The result is a JSON object containing a list of summarized inforation about graphs.
+
+<pre>
+curl -X POST "{{url}}api/graphs/get/" -F "username=[email]" -F "password=[password]" -F "offset=[offset]" -F "limit=[limit]"; echo
+</pre>
+
+Note:
+    <ul>
+        <li><b>Offset</b> is a optional field. Defaults to 10, limits the number of results in the response. Maximum is 1000</li>
+        <li><b>Limit</b> is a optional field. Defaults to 0, used to offset the resultlist.</li>
+    </ul>
+
+Example response:
+
+<pre>
+{
+  "metadata": {
+    "count": 2,
+    "limit": "25",
+    "offset": "0"
+  },
+  "result": [
+    {
+      "created_at": "2012-10-25T06:29:26",
+      "owner_email": "[email]",
+      "updated_at": "2013-10-16T17:49:51",
+      "num_edges": 2,
+      "num_nodes": 1,
+      "graphname": "tutorial_graph1"
+    },
+    {
+      "created_at": "2012-10-25T07:03:10",
+      "owner_email": "[email]",
+      "updated_at": "2013-10-16T17:50:13",
+      "num_edges": 2,
+      "num_nodes": 1,
+      "graphname": "tutorial_graph2"
+    }
+  "StatusCode": 200
+}
+</pre>
+
+
 <h3 style="padding-top: 50px; margin-top: -40px;" id="make_graph_public">Make graph public</h3>
 
 Makes a specific graph that user owns public (viewable to all users of GS). All layouts shared with groups will also become public.
@@ -822,6 +877,105 @@ Example successful response:
     "StatusCode": 200
 }
 </pre>
+
+<h2 style="padding-top: 50px; margin-top: -40px;" id="layouts">Layouts</h2>
+
+<h3 style="padding-top: 50px; margin-top: -40px;" id='get_graph_layouts'>Get all layouts for a Graph</h3>
+
+Get all the layouts that are attached to a certain graph.
+<pre>
+curl -X POST "{{url}}api/users/[email]/graph/[graphname]/layouts/get" -F "username=[email]" -F "password=[password]"; echo
+</pre>
+
+Example successful response:
+<pre>
+{
+    "metadata": {
+        "count": 2,
+        "limit": 10,
+        "offset": 0
+    },
+    "result": [
+        {
+            "graph_id": "tutorial_graph1",
+            "layout_id": 3,
+            "json": "{}",
+            "user_id": "[email]",
+            "layout_name": "test_layout1",
+            "owner_id": "[email]"
+        },
+        {
+            "graph_id": "tutorial_graph2",
+            "layout_id": 607,
+            "json": "{}",
+            "user_id": "[email]",
+            "layout_name": "test_layout2",
+            "owner_id": "[email]"
+        }
+    ],
+    "StatusCode": 200
+}
+</pre>
+
+<h3 style="padding-top: 50px; margin-top: -40px;" id='get_layout'>Get layout</h3>
+
+To get the JSON for an existing layout use the following command. You can only get the JSON for a layout that belongs to you or is shared with a group you belong to or available for public access. Here, [layout_id] refers to id of the layout whose JSON you are trying to retrieve.
+<pre>
+curl -X POST "{{url}}layouts/get/[layout_id]" -F "username=[email]" -F "password=[password]"; echo
+</pre>
+
+Example successful response:
+<pre>
+{
+  "graph_id": "[graph_id]",
+  "layout_id": [layout_id],
+  "json": "[layout_json]",
+  "user_id": "[graph_owner]",
+  "layout_name": "[layout_name]",
+  "owner_id": "[layout_owner]"
+}
+</pre>
+
+<h3 style="padding-top: 50px; margin-top: -40px;" id='create_layout'>Create layout</h3>
+
+In order to add a layout to a graph, make the following POST request where [email] is your email, [password] is your password, [layout_name] is the name of layout and [json] is the layout data as a JSON string.
+
+<pre>
+curl -X POST "{{url}}api/users/[email]/graph/[graphname]/layouts/add" -F "username=[email]" -F "password=[password]" -F "json=[json]" -F "layout_name=[layout_name]"; echo
+</pre>
+
+Example successful response:
+<pre>
+{
+  "Message": "Added [layout_name] layout with id=619.",
+  "StatusCode": 201
+}
+</pre>
+
+<h3 style="padding-top: 50px; margin-top: -40px;" id='update_layout'>Update layout</h3>
+
+If a user wants to update any information for a specific layout, they can do so using this command. The user uploads the modified JSON of the layout to the server. Note, a user can only update a layout if it already exists in GraphSpace for that user.
+<pre>
+curl -X POST "{{url}}layouts/update/[layout_id]" -F "username=[email]" -F "password=[password]" -F "json=[json]"; echo
+</pre>
+
+Example successful response:
+<pre>
+{
+  "Message": "Updated Layout with id=[layout_id].",
+  "StatusCode": 201
+}
+</pre>
+
+Example failed response:
+<pre>
+{
+  "Error": "No Such Layout Exists!",
+  "StatusCode": 404
+}
+</pre>
+
+
 
 <h2 style="padding-top: 50px; margin-top: -40px;" id="tags">Tags</h2>
 

--- a/graphs/templates/graphs/help_tutorial.html
+++ b/graphs/templates/graphs/help_tutorial.html
@@ -43,7 +43,7 @@
 <div id="in_search">
 <h2 style="padding-top: 50px; margin-top: -40px;">Searching within Multiple Graphs</h2>
 <br>
-<p>The user searches this list for graphs that contain the protein CTNNB1 (the symbol for &beta;-catenin, a transcriptional regulator in the Wnt signaling pathway) obtaining a reduced list of graphs. The selection of the button "Similar" means that the any protein whose label or identifier contains "CTNNB1" as a prefix will match this search.  This image shows the result of this search. There are six graphs owned by the user and two public graphs that contain this protein. Each link in the "Graph Id" column will take the user to a specific graph with the search term highlighted.</p>
+<p>The user searches this list for graphs that contain the protein CTNNB1 (the symbol for &beta;-catenin, a transcriptional regulator in the Wnt signaling pathway) obtaining a reduced list of graphs. The selection of the button "Similar" means that the any protein whose label or identifier contains "CTNNB1" as a substring will match this search.  This image shows the result of this search. There are six graphs owned by the user and two public graphs that contain this protein. Each link in the "Graph Id" column will take the user to a specific graph with the search term highlighted.</p>
 <img width="80%" height="80%" align="middle" src="../../static/images/graph_search.png"></img>
 
 <br><br>
@@ -58,7 +58,7 @@
 <p>The same search interface greets the user on the page for this graph, which allows the user to add more search terms for nodes (Wnt in this example).</p>
 <img width="80%" height="80%" align="middle" src="../../static/images/in_search.png"></img>
 <br><br>
-<p>The user can also add search terms for edges ("Wnt:Fzd" in this example). Since the user has selected the "similar" option for the search, any edge whose tail node contains "Wnt" and whose head contains "Fzd" matches the query.</p>
+<p>The user can also add search terms for edges ("Wnt:Fzd" in this example). Since the user has selected the "similar" option for the search, any edge whose tail node identifier or label contains "Wnt" and whose head node identifier or label contains "Fzd" matches the query.</p>
 <br>
 <img width="80%" height="80%" align="middle" src="../../static/images/search_edge.png"></img>
 <br><br>

--- a/graphs/urls.py
+++ b/graphs/urls.py
@@ -90,9 +90,16 @@ urlpatterns = patterns('',
         url(r'^api/users/(?P<user_id>.+)/graph/makeGraphPrivate/(?P<graphname>.+)/$', views.make_graph_private, name='make_graph_private'),
         url(r'^api/users/(?P<user_id>.+)/graphs/$', views.view_all_graphs_for_user, name='view_all_graphs_for_user'),
 
+
+        url(r'^api/layouts/get/(?P<layout_id>.+)$', views.retrieve_layout, name='retrieve_layout'),
+        url(r'^api/layouts/update/(?P<layout_id>.+)$', views.update_graph_layout, name='update_graph_layout'),
+        url(r'^api/users/(?P<user_id>.+)/graph/(?P<graphname>.+)/layouts/add$', views.upload_layout, name='upload_graph'),
+        url(r'^api/users/(?P<user_id>.+)/graph/(?P<graphname>.+)/layouts/get', views.get_graph_layouts, name='get_graph_layout'),
+
         # Group REST API endpoints
         url(r'^api/groups/get/(?P<group_owner>.+)/(?P<groupname>.+)/$', views.get_group, name='get_group'),
         url(r'^api/groups/get/$', views.get_groups, name='get_groups'),
+        url(r'^api/graphs/get/$', views.get_graphs, name='get_graphs'),
         url(r'^api/groups/add/(?P<group_owner>.+)/(?P<groupname>.+)/$', views.add_group, name='add_group'),
         url(r'^api/groups/delete/(?P<group_owner>.+)/(?P<groupname>.+)/$', views.delete_group, name='delete_group'),
         url(r'^api/users/(?P<user_id>.+)/groups/$', views.get_group_for_user, name='get_group_for_user'),

--- a/graphs/views.py
+++ b/graphs/views.py
@@ -1,25 +1,16 @@
-from django.shortcuts import render, redirect
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.http import HttpResponse, HttpResponseRedirect, Http404
-from django.views import generic
-from django.templatetags.static import static
-
-from django.shortcuts import render_to_response
-
-from graphs.util.paginator import pager
-from graphs.util import db
-from graphs.auth.login import login
-from forms import LoginForm, SearchForm, RegisterForm
-from django.conf import settings
-
 import json
-import bcrypt
-import os
 import operator
 
-from operator import itemgetter
-from itertools import groupby
+import bcrypt
+
+from django.conf import settings
+from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import render
+from forms import SearchForm
+from graphs.auth.login import login
 from graphs.forms import LoginForm, RegisterForm
+from graphs.util import db
+from graphs.util.paginator import pager
 
 URL_PATH = settings.URL_PATH
 
@@ -355,10 +346,10 @@ def save_layout(request, uid, gid):
             return HttpResponse(json.dumps(db.throwError(500, "Must be signed in to save a layout!")), content_type="application/json")
 
         result = db.save_layout(gid, graph_owner, request.POST['layout_name'], request.POST['loggedIn'], request.POST['points'], request.POST['public'], request.POST['unlisted'])
-        if result == None:
+        if result != None:
             return HttpResponse(json.dumps(db.sendMessage(200, "Layout saved!")), content_type="application/json")
         
-        return HttpResponse(json.dumps(db.throwError(400, result)), content_type="application/json")
+        return HttpResponse(json.dumps(db.throwError(400, "Layout with this name already exists for this graph! Please choose another name.")), content_type="application/json")
 
     else:
         context = {"Error": "This route only accepts POST requests."}
@@ -1890,6 +1881,159 @@ def update_graph(request, user_id, graphname):
         context = {"Error": "This route only accepts POST requests."}
         return render(request, 'graphs/error.html', context)
 
+def get_graph_layouts(request, user_id, graphname):
+    """
+        Get all layouts for a specified graph.
+
+        If the user has admin access, he can fetch any layout specific to the graph on the server.
+        Otherwise user can fetch public layouts and layouts owned by the user.
+
+        :param request: Incoming HTTP POST Request containing:
+
+        {"username": <username>,"password": <password>}
+
+        :param user_id: Id of the user
+        :param graphname: Name of the graph
+
+        :return response: JSON Response: {"Layouts|Error": <message>}
+    """
+    if request.method == 'POST':
+        user = db.get_valid_user(request.POST.get('username', ''), request.POST.get('password', ''))
+        if user == None:
+            return HttpResponse(json.dumps(db.userNotFoundError(), indent=4, separators=(',', ': ')), content_type="application/json")
+        if user_id is None or graphname is None:
+            return HttpResponse(json.dumps(db.throwError(404, "Bad Request!"), indent=4, separators=(',', ': ')), content_type="application/json")
+
+        if user.admin == 1:
+            total, layouts = db.get_layouts(offset=request.POST.get('offset', 0), limit=request.POST.get('limit', 10), graph_owner=user_id, graphname=graphname)
+        else:
+            total, layouts = db.get_layouts(offset=request.POST.get('offset', 0), limit=request.POST.get('limit', 10), layout_owner=user.user_id, graph_owner=user_id, graphname=graphname)
+
+        metadata = {
+                "count": total,
+                "offset": request.POST.get('offset', 0),
+                "limit": request.POST.get('limit', 10)
+            }
+
+        result = []
+        for layout in layouts:
+            result.append({k: getattr(layout, k, None) for k in ['layout_id', 'layout_name', 'owner_id', 'graph_id', 'user_id', 'json']})
+
+        return HttpResponse(json.dumps({"StatusCode": 200, "metadata": metadata, "result": result}, indent=4, separators=(',', ': '), default=date_handler), content_type="application/json")
+    else:
+        context = {"Error": "This route only accepts POST requests."}
+        return HttpResponse(json.dumps({"StatusCode": 400, "Error": context["Error"]}, indent=4, separators=(',', ': ')), content_type="application/json")
+
+
+def retrieve_layout(request, layout_id):
+    '''
+        Retrieves the specified layout
+
+        :param request: Incoming HTTP POST Request containing:
+
+        {"username": <username>,"password": <password>}
+
+        :param layout_id: Id of the layout
+
+        :return response: JSON Response: {"Layout|Error": <message>}
+    '''
+    if request.method == 'POST':
+
+        if db.get_valid_user(request.POST.get('username', ''), request.POST.get('password', '')) == None:
+            return HttpResponse(json.dumps(db.userNotFoundError(), indent=4, separators=(',', ': ')), content_type="application/json")
+
+        layout = db.get_layout(layout_id)
+        if layout != None:
+            if layout.owner_id == request.POST.get('username', '') or layout.public == 1:
+                return HttpResponse(json.dumps({k: getattr(layout, k, None) for k in ['layout_id', 'layout_name', 'owner_id', 'graph_id', 'user_id', 'json']}, indent=4, separators=(',', ': ')), content_type="application/json")
+            else:
+                return HttpResponse(json.dumps(db.userNotAuthorized(), indent=4, separators=(',', ': ')), content_type="application/json")
+        else:
+            return HttpResponse(json.dumps(db.throwError(404, "No Such Layout Exists!"), indent=4, separators=(',', ': ')), content_type="application/json")
+    else:
+        context = {"Error": "This route only accepts POST requests."}
+        return HttpResponse(json.dumps({"StatusCode": 400, "Error": context["Error"]}, indent=4, separators=(',', ': ')), content_type="application/json")
+
+
+def upload_layout(request, user_id, graphname):
+    '''
+        Uploads a layout for a graph
+
+        :param request: Incoming HTTP POST Request containing:
+
+        {"username": <username>,"password": <password>, "layout_name": <layout_name>, "json": <layout_json>}
+
+        :param user_id: Id of the user
+        :param graphname: Name of the graph
+
+        :return response: JSON Response: {"Success|Error": <message>}
+
+    '''
+    if request.method == 'POST':
+
+        # if request.POST['username'] != user_id:
+        #     return HttpResponse(json.dumps(db.usernameMismatchError(), indent=4, separators=(',', ': ')), content_type="application/json")
+        layout_name = request.POST.get('layout_name', None)
+
+
+        if db.get_valid_user(request.POST.get('username', ''), request.POST.get('password', '')) == None:
+            return HttpResponse(json.dumps(db.userNotFoundError(), indent=4, separators=(',', ': ')), content_type="application/json")
+
+        if request.POST['username'] != user_id:
+            return HttpResponse(json.dumps(db.usernameMismatchError(), indent=4, separators=(',', ': ')), content_type="application/json")
+
+        if layout_name == None:
+            return HttpResponse(json.dumps(db.throwError(400, 'Layout name is required !'), indent=4, separators=(',', ': ')), content_type="application/json")
+
+        layout = db.save_layout(graphname, user_id, layout_name, request.POST.get('username', ''), request.POST.get('json', '{}'), public=0, shared_with_groups=0)
+
+        if layout == None:
+            return HttpResponse(json.dumps(db.throwError(400, "Layout with this name already exists for this graph! Please choose another name."), indent=4, separators=(',', ': ')), content_type="application/json")
+        else:
+            return HttpResponse(json.dumps(db.sendMessage(201, "Added " + layout_name + " layout with id=" + str(layout.layout_id) + '.'), indent=4, separators=(',', ': ')), content_type="application/json")
+    else:
+        context = {"Error": "This route only accepts POST requests."}
+        return HttpResponse(json.dumps({"StatusCode": 400, "Error": context["Error"]}, indent=4, separators=(',', ': ')), content_type="application/json")
+
+
+def update_graph_layout(request, layout_id):
+    '''
+        Updates an already existing layout.
+
+        :param request: Incoming HTTP POST Request containing:
+
+        {"username": <username>,"password": <password>, "json": <layout_json>}
+
+        :param layout_id: Id of the layout
+
+        :return response: JSON Response: {"Success|Error": <message>}
+    '''
+
+    if request.method == 'POST':
+
+        if db.get_valid_user(request.POST.get('username', ''), request.POST.get('password', '')) == None:
+            return HttpResponse(json.dumps(db.userNotFoundError(), indent=4, separators=(',', ': ')), content_type="application/json")
+
+        layout = db.get_layout(layout_id)
+        if layout != None:
+            if layout.owner_id == request.POST.get('username', ''):
+                layout_json = request.POST.get('json', layout.json)
+                error = db.update_layout(layout.graph_id, layout.user_id, layout.layout_name, layout.owner_id, layout_json, layout.public, layout.shared_with_groups, layout.original_json)
+                if error != None:
+                    return HttpResponse(json.dumps(db.throwError(404, error), indent=4, separators=(',', ': ')), content_type="application/json")
+                else:
+                    return HttpResponse(json.dumps(db.sendMessage(201, "Updated Layout with id=" + str(layout_id) + '.'), indent=4, separators=(',', ': ')), content_type="application/json")
+            else:
+                return HttpResponse(json.dumps(db.usernameMismatchError(), indent=4, separators=(',', ': ')), content_type="application/json")
+        else:
+            return HttpResponse(json.dumps(db.throwError(404, "No Such Layout Exists!"), indent=4, separators=(',', ': ')), content_type="application/json")
+
+
+    else:
+        context = {"Error": "This route only accepts POST requests."}
+        return HttpResponse(json.dumps({"StatusCode": 400, "Error": context["Error"]}, indent=4, separators=(',', ': ')), content_type="application/json")
+
+
 def retrieve_graph(request, user_id, graphname):
     '''
         Retrieves the json of a specified graph
@@ -1904,21 +2048,21 @@ def retrieve_graph(request, user_id, graphname):
         :return response: JSON Response: {"Graph|Error": <message>}
     '''
     if request.method == 'POST':
-
-        if request.POST['username'] != user_id:
-            return HttpResponse(json.dumps(db.usernameMismatchError(), indent=4, separators=(',', ': ')), content_type="application/json")
-
-        if db.get_valid_user(user_id, request.POST['password']) == None:
+        user = db.get_valid_user(request.POST.get('username', ''), request.POST.get('password', ''))
+        if user == None:
             return HttpResponse(json.dumps(db.userNotFoundError(), indent=4, separators=(',', ': ')), content_type="application/json")
 
-        jsonData = db.get_graph_json(user_id, graphname)
-        if jsonData != None:
-            return HttpResponse(jsonData)
+        graph = db.get_graph(user_id, graphname)
+        if graph != None:
+            if graph.user_id == request.POST.get('username', '') or graph.public == 1 or user.admin == 1:
+                return HttpResponse(graph.json)
+            else:
+                return HttpResponse(json.dumps(db.usernameMismatchError(), indent=4, separators=(',', ': ')), content_type="application/json")
         else:
             return HttpResponse(json.dumps(db.throwError(404, "No Such Graph Exists!"), indent=4, separators=(',', ': ')), content_type="application/json")
     else:
         context = {"Error": "This route only accepts POST requests."}
-        return render(request, 'graphs/error.html', context)
+        return HttpResponse(json.dumps({"StatusCode": 400, "Error": context["Error"]}, indent=4, separators=(',', ': ')), content_type="application/json")
 
 def remove_graph(request, user_id, graphname):
     '''
@@ -2049,6 +2193,67 @@ def get_groups(request):
     else:
         context = {"Error": "This route only accepts POST requests."}
         return render(request, 'graphs/error.html', context)
+
+
+def date_handler(obj):
+    """
+    Serializes the datetime object.
+
+    Added because datetime.date() is not JSON serializable in Django
+
+    http://stackoverflow.com/questions/23285558/datetime-date2014-4-25-is-not-json-serializable-in-django
+    """
+    if hasattr(obj, 'isoformat'):
+        return obj.isoformat()
+    else:
+        raise TypeError
+
+
+def get_graphs(request):
+    """
+        Get all graphs that are on this server.
+
+        If the user has admin access, he can fetch any graph on the server.
+        Otherwise user can fetch public graphs and graphs owned by the user.
+
+        :param request: Incoming HTTP POST Request containing:
+
+        {"username": <username>,"password": <password>, "tag": <tag>}
+
+        :return response: JSON Response: {"Graphs|Error": <message>}
+    """
+    if request.method == 'POST':
+        user = db.get_valid_user(request.POST.get('username', ''), request.POST.get('password', ''))
+        if user == None:
+            return HttpResponse(json.dumps(db.userNotFoundError(), indent=4, separators=(',', ': ')), content_type="application/json")
+
+        if user.admin == 1:
+            total, graphs = db.get_graphs(offset=request.POST.get('offset', 0), limit=request.POST.get('limit', 10), tag=request.POST.get('tag', None))
+        else:
+            total, graphs = db.get_graphs(offset=request.POST.get('offset', 0), limit=request.POST.get('limit', 10), tag=request.POST.get('tag', None), graph_owner=user.user_id)
+
+        metadata = {
+                "count": total,
+                "offset": request.POST.get('offset', 0),
+                "limit": request.POST.get('limit', 10)
+            }
+
+        result = []
+        for graph in graphs:
+            result.append({
+                "graphname": graph.graph_id,
+                "owner_email": graph.user_id,
+                "created_at": graph.created,
+                "updated_at": graph.modified,
+                "num_edges": len(json.loads(graph.json).get("graph", {}).get("edges", [])),
+                "num_nodes": len(json.loads(graph.json).get("graph", {}).get("nodes", [])),
+            })
+
+        return HttpResponse(json.dumps({"StatusCode": 200, "metadata": metadata, "result": result}, indent=4, separators=(',', ': '), default=date_handler), content_type="application/json")
+    else:
+        context = {"Error": "This route only accepts POST requests."}
+        return HttpResponse(json.dumps({"StatusCode": 400, "Error": context["Error"]}, indent=4, separators=(',', ': ')), content_type="application/json")
+
 
 def get_group(request, group_owner, groupname):
     '''

--- a/graphspace/settings/base.py
+++ b/graphspace/settings/base.py
@@ -42,24 +42,24 @@ WSGI_APPLICATION = 'graphspace.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.6/ref/settings/#databases
 
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-#         'NAME': 'graphspace',
-#         'USER': 'adb',
-#         'PASSWORD': '',
-#         'HOST': 'localhost',
-#         'PORT': '5432'
-#     }
-# }
-
-## Old Sqlite Implementation ###
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'graphspace.db')
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'migrate3',
+        'USER': 'adb',
+        'PASSWORD': '',
+        'HOST': 'localhost',
+        'PORT': '5432'
     }
 }
+
+## Old Sqlite Implementation ###
+# DATABASES = {
+#     'default': {
+#         'ENGINE': 'django.db.backends.sqlite3',
+#         'NAME': os.path.join(BASE_DIR, 'graphspace.db')
+#     }
+# }
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.6/topics/i18n/


### PR DESCRIPTION
* made changes required for migration to postgreSQL

* Added the get all graphs api. Only users with admin access can use this API to get graphs.

* Added the get all graphs api. Only users with admin access can use this API to get graphs. (#204)

* added num of nodes and num of edges to the get graphs api

* Changed implementation of get graph api. Now if a user is trying to fetch a public graph. He can access it even if he isnt the owner of graph.

* - utils/db.py
* Changed the save_layout function - it now returns the newly saved layout if the new layout is saved else it will return None.
* Added get_layout function - It returns the layouts for the given graph. If the requesting user has admin access, he can fetch any layout specific to the graph on the server. Otherwise user can fetch public layouts and layouts owned by the user.

- urls.py

* Added four new urls.
** /api/layouts/get/<layout_id> - To get the layout with given layout id.
** /api/layouts/update/<layout_id> - To update the given layout
** /api/users/<user_id>/graph/<graph_id>/layouts/add - To add a layout for the given graph.
** /api/users/<user_id>/graph/<graph_id>/layouts/get - To get all layouts for the given graph.

- views.py

* Added three new methods
** retrieve_layout - retrieves the specified layout.
** upload_layout - uploads the given layout.
** update_graph_layout - Update the given layout.
** get_graph_layouts - get layouts for the given graph.  If the user has admin access, he can fetch any layout specific to the graph on the server. Otherwise user can fetch public layouts and layouts owned by the user.

* Updated the get_graphs method
** Instead of fetching all graphs (private/public) the api will fetch all public graphs and graphs owned by the user (non-admin user)
** If the user has admin access, he will be able to fetch all graphs (public/private).
** Added a tag field in the post form. If included the results will be filtered on the basis of the given tag.

* Added documentation for get all graphs api and changed the range query to ilike query for similar edge search

* Changed Like queries to ILIKE queries. Added new indexes on node id and labels to suuport faster ILIKE queries.
Fixed a typo bug (layoud to layout)

* Changed the documentation on tutorial pages for similar search from prefix search to substring search.

* Fixing connection closed error when multiple requests are sent to \graphs?partial_search=<sjh> page. Also added the missing session close for some queries.(Not relevant to the fix.)

## Explanation
- The error was occurring because session on a thread was getting closed by another thread. We were closing a session before initiating a new session for a thread. This inturn closed a session which was opened by another thread.

* Fixed the search for node and edges \graphs page.

==================
* Changes
** db.py
- find_all_graphs_containing_edges - updated the query to database
- find_all_graphs_containing_nodes - updated the query to database

* Changing pool size for connection pool. Setting it to pool_size to 20 and max_overflow to 100 for now.  This means 120 concurrent connections are possible right now.

Reference:
http://docs.sqlalchemy.org/en/latest/core/engines.html

* Added the documentation to the new layout related APIs.