### PR TITLE
For issue #293 Layout overwrites 'font-size' node attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GraphSpace has three dummy users:
 Requirements
 ===================================
 1. Python v2.7.10
-2. [postgreSQL](https://github.com/Murali-group/GraphSpace/wiki/PostgreSQL-Installation)
+2. [postgreSQL](https://github.com/Murali-group/GraphSpace/wiki/PostgreSQL-Installation) with pg_trgm extension
 3. virtualenv
 4. [bower](https://bower.io/)
 5. [ElasticSearch](https://github.com/Murali-group/GraphSpace/wiki/Steps-for-setting-up-ElasticSearch-on-AWS)

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -1305,6 +1305,7 @@ var graphPage = {
         }
     },
     layoutEditor: {
+        original_opacity: {},
         undoRedoManager: null,
         init: function () {
             cytoscapeGraph.contextMenu.init(graphPage.cyGraph);
@@ -2270,7 +2271,7 @@ var cytoscapeGraph = {
         cy.style()
             .selector('node').style({
                 'text-opacity': function( ele ){
-                original_opacity[ele.data().id] = ele.style()['text-opacity'];
+                graphPage.layoutEditor.original_opacity[ele.data().id] = ele.style()['text-opacity'];
 
                 return 0; }
             })
@@ -2284,7 +2285,7 @@ var cytoscapeGraph = {
         cy.style()
             .selector('node').style({
                 'text-opacity': function( ele ){
-                    return  original_opacity[ele.data().id];
+                    return  graphPage.layoutEditor.original_opacity[ele.data().id];
                 }
             })
             .update();
@@ -2615,5 +2616,3 @@ var cytoscapeGraph = {
     }
 
 };
-
-var original_opacity = {};

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -2269,18 +2269,23 @@ var cytoscapeGraph = {
          */
         cy.style()
             .selector('node').style({
-                'font-size': "0px"
+                'text-opacity': function( ele ){
+                original_opacity[ele.data().id] = ele.style()['text-opacity'];
+
+                return 0; }
             })
             .update(); // update the elements in the graph with the new style
 
     },
     showGraphInformation: function (cy) {
-        /*
+         /*
          Function to Show information about the graph that the layout editor hid from the users.
          */
         cy.style()
             .selector('node').style({
-                'font-size': "16px"
+                'text-opacity': function( ele ){
+                    return  original_opacity[ele.data().id];
+                }
             })
             .update();
         console.log('done');
@@ -2610,3 +2615,5 @@ var cytoscapeGraph = {
     }
 
 };
+
+var original_opacity = {};

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,10 +47,10 @@
     <script src="{% static 'components/bootstrap/dist/js/bootstrap.js' %}"></script>
     <script src="{% static 'components/bootstrap/js/tooltip.js' %}"></script>
     <script src="{% static 'components/bootstrap/js/popover.js' %}"></script>
-    <script src="{% static "components/bootstrap-table/src/bootstrap-table.js" %}"></script>
-    <script src="{% static "components/lodash/dist/lodash.min.js" %}"></script>
-    <script src="{% static "components/moment/min/moment.min.js" %}"></script>
-    <script src="{% static "components/remarkable-bootstrap-notify/dist/bootstrap-notify.min.js" %}"></script>
+    <script src="{% static 'components/bootstrap-table/src/bootstrap-table.js' %}"></script>
+    <script src="{% static 'components/lodash/dist/lodash.min.js' %}"></script>
+    <script src="{% static 'components/moment/min/moment.min.js' %}"></script>
+    <script src="{% static 'components/remarkable-bootstrap-notify/dist/bootstrap-notify.min.j' %}"></script>
 
     {% google_analytics %}
 


### PR DESCRIPTION
Instead of setting the font-size as 0 pt, graphs_page.js file created original_opacity hashmap for text-opacity for each node and save the 'text-opacity' into hashmap. When #toggleNodeLabels is clicked, hideGraphInformation save 'text-opacity' style for each node into original_opacity{} and set 'text-opacity' to 0. When #toggleNodeLabels is unchecked, showGraphInformation sets 'text-opacity' back to the original 'text-opacity' of each node by calling the value from the original_opacity hashmap.

By using this method, each node can use font-size and text-opacity from json file independently and the script updates each node.

![1](https://user-images.githubusercontent.com/9061404/28891124-66a36aa2-7797-11e7-9a17-89d032d0f27f.png)
![2](https://user-images.githubusercontent.com/9061404/28891127-681c26d0-7797-11e7-9ce4-4d0f86b22108.png)
![3](https://user-images.githubusercontent.com/9061404/28891134-69b5a46c-7797-11e7-9a63-cd7bc3dfc2b1.png)
![4](https://user-images.githubusercontent.com/9061404/28891135-6b2ff5e0-7797-11e7-95fb-18a1d9e5b13f.png)


