### PR TITLE
issue #279  Search for nodes and edges not working on private graphs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GraphSpace has three dummy users:
 Requirements
 ===================================
 1. Python v2.7.10
-2. [postgreSQL](https://github.com/Murali-group/GraphSpace/wiki/PostgreSQL-Installation)
+2. [postgreSQL](https://github.com/Murali-group/GraphSpace/wiki/PostgreSQL-Installation) with pg_trgm extension
 3. virtualenv
 4. [bower](https://bower.io/)
 5. [ElasticSearch](https://github.com/Murali-group/GraphSpace/wiki/Steps-for-setting-up-ElasticSearch-on-AWS)

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -796,10 +796,13 @@ var graphPage = {
                 if (nodes.length > 0) {
                     graphPage.cyGraph.nodes().forEach(function (ele, i, eles) {
                         _.each(nodes, function (node) {
+                            //Check if the node component is not null and include the node string
                             if (node.indexOf(':') === -1 && node.indexOf('>') === -1 && node.indexOf('<') === -1 && node.indexOf('=') === -1) {
-                                if (ele.data('name').toLowerCase().indexOf(node.toLowerCase()) != -1 ||
-                                    ele.data('label').toLowerCase().indexOf(node.toLowerCase()) != -1 ||
-                                    ele.data('aliases').join(' ').toLowerCase().indexOf(node.toLowerCase()) != -1) {
+                                if ((ele.data('name') && ele.data('name').toLowerCase().indexOf(node.toLowerCase()) != -1) ||
+                                    (ele.data('label') && ele.data('label').toLowerCase().indexOf(node.toLowerCase()) != -1) ||
+                                    (ele.data('aliases') && (ele.data('aliases').join(' ').toLowerCase().indexOf(node.toLowerCase()) != -1))
+                                    ) {
+
                                     ele.select();
                                 }
                             } else if (node.indexOf('>') !== -1 || node.indexOf('<') !== -1 || node.indexOf('=') !== -1) {


### PR DESCRIPTION
The issue was caused because some of the nodes do not contain 'aliases' filed in their data and search function is checking 'aliases' field by calling the functions to the null object. 

Added conditions to check data('aliases') is not null and conditions for 'name' and 'label' field additionally for the future reference when the user upload node without node and label #279 