### PR TITLE
Visualization improvement for selecting parent node

### DIFF
--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -428,6 +428,15 @@ var graphPage = {
 
         graphPage.cyGraph.panzoom();
 
+        //Update the parent node array
+        graphPage.cyGraph.nodes().forEach(function (ele) {
+                if (ele.data().parent != null && parent_nodes.indexOf(ele.data().parent) == -1)
+                {
+                    parent_nodes.push(ele.data().parent);
+                }
+
+        });
+
         utils.initializeTabs();
 
         $('#saveLayoutBtn').click(function () {
@@ -1510,38 +1519,53 @@ var graphPage = {
         nodeSelector: {
             init: function () {
                 var colors = _.uniq(_.map(graphPage.cyGraph.nodes(), function (node) {
-                    return node.style('background-color');
+                    //If the ode is a parent node, do not include the color of the parent node to the color option
+                    if (parent_nodes.indexOf(node.data().id) == -1)
+                    {
+                        return node.style('background-color');
+                    }
                 }));
                 $('#selectColors').html('');
                 _.each(colors, function (color) {
-                    $('#selectColors').append(
-                        $('<label>', {class: "checkbox-inline zero-padding"}).css({
-                            'margin-left': '10px',
-                            'margin-right': '10px'
-                        }).append(
-                            $('<input>', {
-                                id: color,
-                                type: 'checkbox',
-                                value: color,
-                                name: 'colors'
-                            })).append($('<p>', {
-                            class: 'select-color-box'
-                        }).css('background', color)));
+                    if (color != null)
+                    {
+                        $('#selectColors').append(
+                            $('<label>', {class: "checkbox-inline zero-padding"}).css({
+                                'margin-left': '10px',
+                                'margin-right': '10px'
+                            }).append(
+                                $('<input>', {
+                                    id: color,
+                                    type: 'checkbox',
+                                    value: color,
+                                    name: 'colors'
+                                })).append($('<p>', {
+                                class: 'select-color-box'
+                            }).css('background', color)));
+                    }
                 });
 
                 var shapes = _.uniq(_.map(graphPage.cyGraph.nodes(), function (node) {
-                    return node.style('shape');
+                    //If the node is a parent node, do not inlcude the shape of parent node to the option
+                    if (parent_nodes.indexOf(node.data().id) == -1)
+                    {
+                        return node.style('shape');
+                    }
                 }));
                 $('#selectShapes').html('');
                 _.each(shapes, function (shape) {
-                    $('#selectShapes').append(
-                        $('<label>', {class: "checkbox-inline"}).css({'margin-left': '10px'}).append(
-                            $('<input>', {
-                                id: shape,
-                                type: 'checkbox',
-                                value: shape,
-                                name: 'shapes'
-                            })).append(_.capitalize(shape)));
+                    //Do not include the shape of parent node
+                    if (shape != null)
+                    {
+                        $('#selectShapes').append(
+                            $('<label>', {class: "checkbox-inline"}).css({'margin-left': '10px'}).append(
+                                $('<input>', {
+                                    id: shape,
+                                    type: 'checkbox',
+                                    value: shape,
+                                    name: 'shapes'
+                                })).append(_.capitalize(shape)));
+                    }
                 });
 
                 $('input:checkbox[name=shapes], input:checkbox[name=colors] ').change(function () {
@@ -1564,7 +1588,7 @@ var graphPage = {
 
                         if ((selectedColors.length > 0 && _.indexOf(selectedColors, node.style('background-color')) === -1) || (selectedShapes.length > 0 && _.indexOf(selectedShapes, node.style('shape')) === -1)) {
                             node.unselect();
-                        } else if (selectedColors.length > 0 || selectedShapes.length > 0) {
+                        } else if ((selectedColors.length > 0 || selectedShapes.length > 0) && parent_nodes.indexOf(node.data().id) == -1) {
                             node.select();
                         } else {
                             node.unselect();
@@ -2610,3 +2634,5 @@ var cytoscapeGraph = {
     }
 
 };
+
+var parent_nodes = [];


### PR DESCRIPTION
 From issue #285, since selecting parents node by shapes and color behaves bad visualization the child node, select by shapes and color button now only works on the child node. During initialize the graph, the parent nodes are selected and pushed into parent_nodes array. The options of select by shapes and color are also edited into only show options of child nodes' shapes and color.

This design disables the automatic selection for parent node by shape and color. The discussion will be further needed for design perspective.

BEFORE
![2](https://user-images.githubusercontent.com/9061404/29283652-a636d642-80f5-11e7-82d2-d22f5e7006ba.png)

AFTER
![1](https://user-images.githubusercontent.com/9061404/29283669-afcb2ae6-80f5-11e7-9a77-882cf7ea9f5a.png)
