### PR TITLE
Editor for edge curve-style

### DIFF
--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -1725,6 +1725,21 @@ var graphPage = {
                     $('#edgeSourceArrowShape').val(collection.style('source-arrow-shape'));
                     $('#edgeTargetArrowShape').val(collection.style('target-arrow-shape'));
                     $("#edgeLineColorPicker").colorpicker('setValue', collection.style('line-color'));
+
+
+                    //if default (haystack, haystack-radius: 0 set to none
+                    if (collection.style('curve-style') == "haystack" && collection.style("haystack-radius") == "0")
+                    {
+                        $("#edgeBend").val("none");
+                    }
+                    else if (collection.style('curve-style') == "unbundled-bezier" && collection.style("control-point-distances") == "40 -40")
+                    {
+                         $("#edgeBend").val("unbundled-bezier2");
+                    }
+                    else
+                    {
+                        $("#edgeBend").val(collection.style('curve-style'));
+                    }
                     collection.select();
                 } else {
                     $('#edgeWidth').val(null);
@@ -1849,6 +1864,74 @@ var graphPage = {
                         });
                     }
                 });
+
+                 $('#edgeBend').on('change', function (e) {
+                    if (_.isEmpty($('#edgeBend').val())) {
+                        return $.notify({
+                            message: 'Please enter valid edge type!',
+                        }, {
+                            type: 'warning'
+                        });
+                    } else {
+                            //none
+                            //Do nothing
+
+                            //bezier
+                            if ($('#edgeBend').val() == "bezier")
+                            {
+
+                                 graphPage.layoutEditor.edgeEditor.updateEdgeProperty({
+                                 "control-point-step-size": "40px",
+                                 'curve-style': $('#edgeBend').val()
+                                 });
+                            }
+                            //unbndled-bezier
+                            else if ($('#edgeBend').val() == "unbundled-bezier")
+                            {
+                                 graphPage.layoutEditor.edgeEditor.updateEdgeProperty({
+                                  "control-point-distances": "120",
+                                  "control-point-weights": "0.1",
+                                 'curve-style': $('#edgeBend').val()
+                                 });
+                            }
+                            //unbundled-bezier(multiple)
+                            else if ($('#edgeBend').val() == "unbundled-bezier2")
+                            {
+                                 graphPage.layoutEditor.edgeEditor.updateEdgeProperty({
+                                   "control-point-distances": "40 -40",
+                                    "control-point-weights": "0.25 0.75",
+                                 'curve-style': "unbundled-bezier"
+                                 });
+                            }
+                            //haystack
+                            else if ($('#edgeBend').val() == "haystack")
+                            {
+                                 graphPage.layoutEditor.edgeEditor.updateEdgeProperty({
+                                 "haystack-radius": "0.5",
+                                 'curve-style': $('#edgeBend').val()
+                                 });
+                            }
+                            //segments
+                            else if ($('#edgeBend').val() == "segments")
+                            {
+                                 graphPage.layoutEditor.edgeEditor.updateEdgeProperty({
+                                  "segment-weights": "0.25 0.75",
+                                  "segment-distances": "40 -40",
+                                 'curve-style': $('#edgeBend').val()
+                                 });
+                            }
+                            //none
+                            else
+                            {
+                                graphPage.layoutEditor.edgeEditor.updateEdgeProperty({
+                                    //Default settings
+                                    "haystack-radius": "0",
+                                    'curve-style': "haystack"
+                                });
+                            }
+                    }
+                });
+
 
                 $('#nodeBackgroundColorPicker').on('changeColor', graphPage.layoutEditor.edgeEditor.onEdgeLineColorChange);
 

--- a/templates/graph/edge_editor.html
+++ b/templates/graph/edge_editor.html
@@ -57,6 +57,28 @@
                     </select>
                 </div>
             </div>
+
+
+            <div class="form-group">
+                <label for="edgeBend" class="col-sm-4 control-label">Edge Type</label>
+                <div class="col-sm-8">
+                    <select id="edgeBend" class="form-control">
+                        <option value="none">none</option>
+                        <option value="bezier">bezier</option>
+                        <option value="unbundled-bezier">unbundled-bezier</option>
+                        <option value="unbundled-bezier2">unbundled-bezier(multiple)</option>
+                        <option value="haystack">haystack</option>
+                        <option value="segments">segments</option>
+                    </select>
+                </div>
+            </div>
+
+
+
+
+
+
+
         </div>
     </li>
     <li>


### PR DESCRIPTION
Added curve-style selection in edge-editor. It supports all kind of curve-style in Cytoscape(bezier, unbundled-bezier, haystack, and segments), and set ("curve-style":haystack, "haystack-radius":"0") as an option "none". Multiple unbundled-bezier contains two oscillation. When the number of selected edge is one, the initial option appears in Edge Type bar is the type of initial curve-style.

![1](https://user-images.githubusercontent.com/9061404/29292704-24cd1636-8116-11e7-82ed-82068f703396.png)


![2](https://user-images.githubusercontent.com/9061404/29292618-cc0811f4-8115-11e7-8a35-6fa0f29eb4c7.png)

Samples are based on:
![3](https://user-images.githubusercontent.com/9061404/29292644-def7a8b0-8115-11e7-904f-c8a938d66edc.png)
and also available on:
http://graphspace.org/graphs/22771
