### PR TITLE
Added the name of the groups with which a graph is shared to the "Graph Information" tab.

### DIFF
--- a/templates/graph/graph_details_tab.html
+++ b/templates/graph/graph_details_tab.html
@@ -28,6 +28,23 @@
                     {% endfor %}
 
                 </table>
+                <table class="table table-bordered">
+                    <tr>
+                        <th>Shared with groups</th>
+                    </tr>
+
+                    {% if shared_groups %}
+                        {% for k in shared_groups %}
+                            <tr>
+                                <td><a href="{% url 'group' group_id=k.id %}">{{k.name|safe}}</a></td>
+                            </tr>
+                        {% endfor %}
+                    {% else %}
+                        <tr>
+                            <td>'The graph is not shared with any groups'</td>
+                        </tr>
+                    {% endif %}
+                </table>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I added a table with heading `Shared with groups`. In the screenshot below,  the graph is shared with two groups with name `testing_groups` and `testing_group_2` as show in the table.
![screenshot from 2018-02-05 20-40-52](https://user-images.githubusercontent.com/18470647/35812110-1b121ff4-0ab6-11e8-91d0-c462ed8e00a8.png)

Refers https://github.com/Murali-group/GraphSpace/issues/277