### PR TITLE
Added the name of the groups with which a graph is shared to the "Graph Information" tab.

### DIFF
--- a/templates/graph/graph_details_tab.html
+++ b/templates/graph/graph_details_tab.html
@@ -28,6 +28,23 @@
                     {% endfor %}
 
                 </table>
+                <table class="table table-bordered">
+                    <tr>
+                        <th>Shared with groups</th>
+                    </tr>
+
+                    {% if shared_groups %}
+                        {% for k in shared_groups %}
+                            <tr>
+                                <td><a href="{% url 'group' group_id=k.id %}">{{k.name|safe}}</a></td>
+                            </tr>
+                        {% endfor %}
+                    {% else %}
+                        <tr>
+                            <td>'The graph is not shared with any groups'</td>
+                        </tr>
+                    {% endif %}
+                </table>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I added a table with heading `Shared with groups`. In the gif below, the graph is shared with two groups with name `testing_groups` and `testing_group_2` as show in the table. I have also implemented the enhancement proposed to hyperlink each group to the GraphSpace page for the group.
![peek 2018-02-07 18-35](https://user-images.githubusercontent.com/18470647/35983214-92ae0e84-0d17-11e8-9058-68471e97fecc.gif)
 