### PR TITLE
Added Proof of concept Fork functionality 

### DIFF
--- a/applications/graphs/urls.py
+++ b/applications/graphs/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
 	url(r'^graphs/(?P<graph_id>[^/]+)$', views.graph_page, name='graph'),
 	url(r'^graphs/(?P<email>[^/]+)/(?P<graph_name>[^/]+)$', views.graph_page_by_name, name='graph_by_name'),
 	url(r'^upload$', views.upload_graph_page, name='upload_graph'),
+    url(r'^fork_graph$', views.fork_graph, name='fork_graph'),
 
 	# AJAX APIs Endpoints
 

--- a/applications/graphs/views.py
+++ b/applications/graphs/views.py
@@ -34,6 +34,22 @@ def upload_graph_page(request):
 	else:
 		return render(request, 'upload_graph/index.html', context)
 
+@csrf_exempt
+def fork_graph(request):
+    response=''
+    if request.method == 'POST':
+        try:
+            graph = _add_graph(request, graph={
+                'name': request.POST.get('name', None),
+                'owner_email': request.POST.get('owner_email', None),
+                'is_public': request.POST.get('is_public', None),
+                'graph_json': json.loads(request.POST.get('graph_json', None)),
+                'style_json': json.loads(request.POST.get('style_json', None))
+            })
+            response = 'Success'
+        except Exception as e:
+            response = str(e)
+        return HttpResponse(json.dumps({'result':response}), content_type="application/json")
 
 def graphs_page(request):
 	"""

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -441,6 +441,13 @@ var graphPage = {
 
         utils.initializeTabs();
 
+        $("#ForkGraph").click(function (e) {
+            e.preventDefault();
+            if (!$(this).hasClass('disabled')){
+                graphPage.fork($(this).data()); // Passing data about parent graph to fork() as argument
+            }
+        });
+
         $('#saveOnExitLayoutBtn').click(function () {
             graphPage.cyGraph.contextMenus('get').destroy(); // Destroys the cytocscape context menu extension instance.
 
@@ -515,6 +522,34 @@ var graphPage = {
 
 
         graphPage.defaultLayoutWidget.init();
+    },
+    fork: function (data) {
+        //Read the meta_data object and add 'parent_id' & 'parent_email' to the data field.
+        graph_meta_data = cytoscapeGraph.getNetworkAndViewJSON(graphPage.cyGraph);
+        graph_meta_data.data['parent_id'] = data.graph_id;
+        graph_meta_data.data['parent_email'] = data.owner_email;
+        var graphData = {
+            'name':data.graph_name,
+            'is_public':0,
+            'owner_email':data.uid,
+            'graph_json':JSON.stringify(graph_meta_data, null, 4),
+            'style_json':JSON.stringify(cytoscapeGraph.getStyleJSON(graphPage.cyGraph), null, 4)
+        }
+        $.ajax({
+            "type": "POST",
+            "dataType": "json",
+            "url": "/fork_graph",
+            "data": graphData,
+            "success": function (data) {
+                if(data.result=='Success'){
+                    $("#ForkGraph span").text('Forked Successfully');
+                    $("#ForkGraph").addClass('disabled');
+                }
+                else{
+                    alert('Could not fork the Graph due to the following error : ' + data.result);
+                }
+            },
+        });
     },
     export: function (format) {
         cytoscapeGraph.export(graphPage.cyGraph, format, $('#GraphName').val());

--- a/templates/graph/index.html
+++ b/templates/graph/index.html
@@ -178,7 +178,7 @@
                         <i class="fa fa-share-alt fa-lg"></i> Share
                     </a>
                 {% endif %}
-                <div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 20000">
+                <div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 1001">
                     <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown"
                             aria-haspopup="true" aria-expanded="false">
                         <i class="fa fa-download fa-lg"></i> Export <span class="caret"></span>

--- a/templates/graph/index.html
+++ b/templates/graph/index.html
@@ -144,7 +144,7 @@
     <!--- Modals end here--->
     <div class="container-fluid zero-margin zero-padding">
         <div class="row zero-margin zero-padding padding-top-2 padding-bottom-2">
-            <div class="col-md-10">
+            <div class="col-md-9">
                 <p class="lead">
                     {{ title }}
                 </p>
@@ -169,9 +169,33 @@
                         {% endfor %}
                     </div>
                 {% endif %}
+                {% if 'data' in graph.graph_json and 'parent_email' in graph.graph_json.data%}
+                    <p class="small">
+                        <small> forked from {{ graph.graph_json.data.parent_email }}/ <a class="text-center"
+                            href="{% url 'graphs' %}{{ graph.graph_json.data.parent_id }} "> {{ graph.name }} </a> </small>
+                    </p>
+                {% endif %}
             </div>
 
-            <div class="col-md-2">
+            <div class="col-md-3">
+                {% if isForked %}
+                <div class="btn-group" style=": 1em !important; z-index: 20000">
+                    <button type="button" class="btn btn-sm btn-default disabled"
+                            aria-haspopup="true" aria-expanded="false">
+                        <i class="fa fa-code-fork" aria-hidden="true"></i> Forked Successfully
+                    </button>
+
+                </div>
+                {% elif uid != graph.owner_email %}
+                <div class="btn-group pull-right" style=": 1em !important; z-index: 20000">
+                    <button type="button" id='ForkGraph' class="btn btn-sm btn-default"
+                            aria-haspopup="true" aria-expanded="false" data-uid={{ uid }} data-graph_name="{{ title }}"
+                            data-graph_id={{ graph.id }} data-owner_email={{ graph.owner_email }}>
+                        <i class="fa fa-code-fork" aria-hidden="true"></i> <span>Fork</span>
+                    </button>
+
+                </div>
+                {% endif %}
                 {% if uid and uid == graph.owner_email %}
                     <a class="btn btn-default pull-right btn-sm" href="#" data-toggle="modal"
                        data-target="#shareGraphModal">


### PR DESCRIPTION
This patch implements #336 - Allow users to fork/clone a graph. 
The following scenarios are covered : 
1. A user opens a graph he had uploaded himself. 
**Observation -** UI has no **Fork Button** or **forked from message**.
2. User opens a graph he had forked earlier. 
**Observation -** forked from **parent_graph_owner's_email / Name of graph** is displayed. The user can click on this link to go to the parent graph. Similar to what he have on Github.
3. User opens the Parent Graph which he already forked and tries to **Fork** again. 
**Observation -** A message is displayed stating that the user has already forked the graph. 
Github on the other hand, redirects to the existing fork instead of showing any message.
I can implement similar behaviour for Graphspace if desired.
4. User shares a graph to public and tries to fork it himself. 
**Observation -** Same as case 1.

A general scenario would be that User A uploads a graph and shares it to public. User B can then fork the graph as described in the above cases. 


![fork_demo](https://user-images.githubusercontent.com/4581090/36150292-164a1782-10bb-11e8-9e94-b38af54849b4.gif)
