### PR TITLE
Home Page UI Bug Fixed - #367

### DIFF
--- a/static/css/graphspace.css
+++ b/static/css/graphspace.css
@@ -35,6 +35,10 @@ div.container-fluid {
     width: 100%;
 }
 
+.gs-features{
+    margin-bottom:150px;
+}
+
 .zero-margin {
     margin: 0 !important;
 }

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -148,8 +148,8 @@
             </div>
 
         </div>
-        <div class="margin-top-8">
-        <div class="gs-footer padding-top-1 padding-bottom-2">
+
+        <div class="gs-footer padding-top-2 padding-bottom-2">
             <div class="container-fluid">
                 <div class="row">
                     <div class="col-md-8">
@@ -166,4 +166,3 @@
         </div>
     </div>
 {% endblock %}
-

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -148,8 +148,8 @@
             </div>
 
         </div>
-
-        <div class="gs-footer padding-top-2 padding-bottom-2">
+        <div class="margin-top-8">
+        <div class="gs-footer padding-top-1 padding-bottom-2">
             <div class="container-fluid">
                 <div class="row">
                     <div class="col-md-8">


### PR DESCRIPTION
The following had created the issue:
1. The position of header and footer are absolute, thus the total screen size was reduced for other HTML components. The other components of HTML were created not taking into consideration the reduced screen size due to the header and footer. 

I have just reduced the top-padding of the footer by 1unit and increased the top margin of footer by 8units. This makes the bottom text visible. 