### PR TITLE
Fork functionality

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Purpose
+_Describe the problem or feature in addition to a link to the issues._
+
+Example:
+Fixes # .
+
+## Approach
+_How does this change address the problem?_
+
+#### Open Questions and Pre-Merge TODOs
+- [ ] Use github checklists. When solved, check the box and explain the answer.
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons used to solve this problem_
+
+#### Blog Posts
+- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.
+

--- a/applications/graphs/controllers.py
+++ b/applications/graphs/controllers.py
@@ -333,10 +333,11 @@ def delete_graph_to_group(request, group_id, graph_id):
 
 
 def search_graphs1(request, owner_email=None, names=None, nodes=None, edges=None, tags=None, member_email=None,
-                   is_public=None, query=None, limit=20, offset=0, order='desc', sort='name'):
+                   is_public=None, is_forked=None, query=None, limit=20, offset=0, order='desc', sort='name'):
 	sort_attr = getattr(db.Graph, sort if sort is not None else 'name')
 	orber_by = getattr(db, order if order is not None else 'desc')(sort_attr)
 	is_public = int(is_public) if is_public is not None else None
+	is_forked = int(is_forked) if is_forked is not None else None
 
 	if member_email is not None:
 		member_user = users.controllers.get_user(request, member_email)
@@ -362,6 +363,7 @@ def search_graphs1(request, owner_email=None, names=None, nodes=None, edges=None
 	                                    owner_email=owner_email,
 	                                    graph_ids=graph_ids,
 	                                    is_public=is_public,
+										is_forked=is_forked,
 	                                    group_ids=group_ids,
 	                                    names=names,
 	                                    nodes=nodes,
@@ -586,3 +588,9 @@ def add_edge(request, name=None, head_node_id=None, tail_node_id=None, is_direct
 def delete_edge_by_id(request, edge_id):
 	db.delete_edge(request.db_session, id=edge_id)
 	return
+
+def add_graph_to_fork(request, forked_graph_id, parent_graph_id, owner_email):
+	if forked_graph_id is not None and parent_graph_id is not None:
+		db.add_fork(request.db_session, forked_graph_id, parent_graph_id, owner_email)
+	else:
+		raise Exception("Required Parameter is missing!")

--- a/applications/graphs/dal.py
+++ b/applications/graphs/dal.py
@@ -126,7 +126,7 @@ def get_graph_by_id(db_session, id):
 
 
 @with_session
-def find_graphs(db_session, owner_email=None, group_ids=None, graph_ids=None, is_public=None, names=None, nodes=None,
+def find_graphs(db_session, owner_email=None, group_ids=None, graph_ids=None, is_public=None, is_forked=None, names=None, nodes=None,
                 edges=None,
                 tags=None, limit=None, offset=None, order_by=desc(Graph.updated_at)):
 	query = db_session.query(Graph)
@@ -151,6 +151,8 @@ def find_graphs(db_session, owner_email=None, group_ids=None, graph_ids=None, is
 		options_group.append(subqueryload('nodes'))
 	if edges is not None and len(edges) > 0:
 		options_group.append(subqueryload(Graph.edges))
+	if is_forked is not None:
+		options_group.append(joinedload(Graph.forked_graphs))
 	if group_ids is not None and len(group_ids) > 0:
 		options_group.append(joinedload('shared_with_groups'))
 	if len(options_group) > 0:
@@ -158,6 +160,9 @@ def find_graphs(db_session, owner_email=None, group_ids=None, graph_ids=None, is
 
 	if group_ids is not None:
 		query = query.filter(Graph.groups.any(Group.id.in_(group_ids)))
+
+	if is_forked is not None:
+		query = query.filter(Graph.forked_graphs.any())
 
 	edges = [] if edges is None else edges
 	nodes = [] if nodes is None else nodes
@@ -458,3 +463,9 @@ def find_edges(db_session, is_directed=None, names=None, edges=None, graph_id=No
 		query = query.limit(limit).offset(offset)
 
 	return total, query.all()
+
+@with_session
+def add_fork(db_session, forked_graph_id, parent_graph_id, owner_email):
+	fork = GraphFork(name='-', graph_id=forked_graph_id, parent_graph_id=parent_graph_id, owner_email=owner_email)
+	db_session.add(fork)
+	return 1

--- a/applications/graphs/dal.py
+++ b/applications/graphs/dal.py
@@ -466,6 +466,6 @@ def find_edges(db_session, is_directed=None, names=None, edges=None, graph_id=No
 
 @with_session
 def add_fork(db_session, forked_graph_id, parent_graph_id, owner_email):
-	fork = GraphFork(name='-', graph_id=forked_graph_id, parent_graph_id=parent_graph_id, owner_email=owner_email)
+	fork = GraphFork( graph_id=forked_graph_id, parent_graph_id=parent_graph_id, owner_email=owner_email)
 	db_session.add(fork)
 	return 1

--- a/applications/graphs/models.py
+++ b/applications/graphs/models.py
@@ -32,6 +32,8 @@ class Graph(IDMixin, TimeStampMixin, Base):
 	edges = relationship("Edge", back_populates="graph", cascade="all, delete-orphan")
 	nodes = relationship("Node", back_populates="graph", cascade="all, delete-orphan")
 
+	forked_graphs = relationship("GraphFork", foreign_keys="GraphFork.graph_id", back_populates="graph", cascade="all, delete-orphan")
+
 	groups = association_proxy('shared_with_groups', 'group')
 	tags = association_proxy('graph_tags', 'tag')
 
@@ -273,6 +275,24 @@ class GraphToTag(TimeStampMixin, Base):
 	tag = relationship("GraphTag", backref=backref("tagged_graphs", cascade="all, delete-orphan"), uselist=False)
 
 	indices = (Index('graph2tag_idx_graph_id_tag_id', 'graph_id', 'tag_id'),)
+	constraints = ()
+
+	@declared_attr
+	def __table_args__(cls):
+		args = cls.constraints + cls.indices
+		return args
+
+
+class GraphFork(IDMixin, TimeStampMixin, Base):
+	__tablename__ = 'graph_fork'
+	#name = Column(String, nullable=False)
+	owner_email = Column(String, ForeignKey('user.email', ondelete="CASCADE", onupdate="CASCADE"), nullable=False)
+	graph_id = Column(Integer, ForeignKey('graph.id', ondelete="CASCADE", onupdate="CASCADE"), nullable=False)
+	parent_graph_id = Column(Integer, ForeignKey('graph.id', ondelete="CASCADE", onupdate="CASCADE"), nullable=False)
+
+	graph = relationship("Graph", foreign_keys=[graph_id], back_populates="forked_graphs", uselist=False)
+
+	indices = (Index('graph2fork_idx_graph_id_parent_id', 'graph_id', 'parent_graph_id'),)
 	constraints = ()
 
 	@declared_attr

--- a/applications/graphs/urls.py
+++ b/applications/graphs/urls.py
@@ -27,6 +27,8 @@ urlpatterns = [
 	# Graph Layouts
 	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/layouts/$', views.graph_layouts_ajax_api, name='graph_layouts_ajax_api'),
 	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/layouts/(?P<layout_id>[^/]+)$', views.graph_layouts_ajax_api, name='graph_layouts_ajax_api'),
+	# Graph Fork
+	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/fork/$', views.graph_fork_ajax_api, name='graph_fork_ajax_api'),
 
 	# REST APIs Endpoints
 
@@ -45,5 +47,7 @@ urlpatterns = [
 	# Graph Layouts
 	url(r'^api/v1/graphs/(?P<graph_id>[^/]+)/layouts/$', views.graph_layouts_rest_api, name='graph_layouts_rest_api'),
 	url(r'^api/v1/graphs/(?P<graph_id>[^/]+)/layouts/(?P<layout_id>[^/]+)$', views.graph_layouts_rest_api, name='graph_layouts_rest_api'),
+	# Graph Fork
+	url(r'^api/v1/graphs/(?P<graph_id>[^/]+)/fork/$', views.graph_fork_rest_api, name='graph_fork_rest_api'),
 
 ]

--- a/graphspace/settings/local.py
+++ b/graphspace/settings/local.py
@@ -39,9 +39,9 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'nrnb',
-        'USER': 'postgres',
-        'PASSWORD': '123',
+        'NAME': 'test_database',
+        'USER': 'adb',
+        'PASSWORD': '',
         'HOST': 'localhost',
         'PORT': '5432'
     }

--- a/graphspace/settings/local.py
+++ b/graphspace/settings/local.py
@@ -39,9 +39,9 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'test_database',
-        'USER': 'adb',
-        'PASSWORD': '',
+        'NAME': 'nrnb',
+        'USER': 'postgres',
+        'PASSWORD': '123',
         'HOST': 'localhost',
         'PORT': '5432'
     }

--- a/migration/versions/bdce7c016932_add_graph_fork_table.py
+++ b/migration/versions/bdce7c016932_add_graph_fork_table.py
@@ -1,0 +1,24 @@
+"""add_graph_fork_table
+
+Revision ID: bdce7c016932
+Revises: bb9a45e2ee5e
+Create Date: 2018-05-19 16:15:09.911000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'bdce7c016932'
+down_revision = 'bb9a45e2ee5e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    op.drop_table('graph_fork')

--- a/templates/graph/index.html
+++ b/templates/graph/index.html
@@ -144,7 +144,7 @@
     <!--- Modals end here--->
     <div class="container-fluid zero-margin zero-padding">
         <div class="row zero-margin zero-padding padding-top-2 padding-bottom-2">
-            <div class="col-md-10">
+            <div class="col-md-9">
                 <p class="lead">
                     {{ title }}
                 </p>
@@ -169,9 +169,34 @@
                         {% endfor %}
                     </div>
                 {% endif %}
+                {% if 'data' in graph.graph_json and 'parent_email' in graph.graph_json.data%}
+                    <p class="small">
+                        <small> forked from {{ graph.graph_json.data.parent_email }}/ <a class="text-center"
+                            href="{% url 'graphs' %}{{ graph.graph_json.data.parent_id }} "> {{ graph.name }} </a> </small>
+                    </p>
+                {% endif %}
             </div>
 
-            <div class="col-md-2">
+            <div class="col-md-3">
+                {% if isForked %}
+                <div class="btn-group" style=": 1em !important; z-index: 20000">
+                    <button type="button" class="btn btn-sm btn-default disabled"
+                            aria-haspopup="true" aria-expanded="false">
+                        <i class="fa fa-code-fork" aria-hidden="true"></i> Forked Successfully
+                    </button>
+
+                </div>
+
+                {% elif uid != graph.owner_email %}
+                <div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 20000">
+                    <button type="button" id='ForkGraph' class="btn btn-sm btn-default"
+                            aria-haspopup="true" aria-expanded="false" data-uid={{ uid }} data-graph_name="{{ title }}"
+                            data-graph_id={{ graph.id }} data-owner_email={{ graph.owner_email }}>
+                        <i class="fa fa-code-fork" aria-hidden="true"></i> <span>Fork</span>
+                    </button>
+
+                </div>
+                {% endif %}
                 {% if uid and uid == graph.owner_email %}
                     <a class="btn btn-default pull-right btn-sm" href="#" data-toggle="modal"
                        data-target="#shareGraphModal">

--- a/templates/graphs/forked_graphs_table.html
+++ b/templates/graphs/forked_graphs_table.html
@@ -1,0 +1,35 @@
+<table id="ForkedGraphsTable"
+       data-toggle="table"
+       data-show-refresh="true"
+       data-show-columns="false"
+       data-show-toggle="true"
+       data-query-params="graphsPage.graphsTable.queryParams"
+       data-ajax="graphsPage.forkedGraphsTable.getForkedGraphs"
+       data-side-pagination="server"
+       data-data-field="graphs"
+       data-pagination="true"
+       data-sort-name="updated_at"
+       data-id-field="id"
+       data-sort-order="desc">
+    <thead>
+    <tr>
+        <th data-field="name" data-sortable="True"
+            data-formatter="graphsPage.graphsTable.graphNameFormatter">Graph Name
+        </th>
+        <th data-field="tags" data-formatter="graphsPage.graphsTable.tagsFormatter">Tags</th>
+        <th data-field="owner_email" data-formatter="graphsPage.graphsTable.ownerEmailFormatter" data-sortable="True">Graph
+            Owner
+        </th>
+        <th data-field="updated_at" data-formatter="utils.dateFormatter" data-sortable="True">Last
+            Modified
+        </th>
+        <th data-field="is_public" data-sortable="True"
+            data-formatter="graphsPage.graphsTable.visibilityFormatter">Visibility
+        </th>
+        <th data-field="operations" data-formatter="graphsPage.graphsTable.operationsFormatter"
+            data-events="graphsPage.graphsTable.operationEvents">
+            Operations
+        </th>
+    </tr>
+    </thead>
+</table>

--- a/templates/graphs/index.html
+++ b/templates/graphs/index.html
@@ -23,6 +23,11 @@
                                                                                class="badge">{{ public_graphs.total }}</span></a>
             </li>
 
+            <li class="text-center {% if not uid %} active {% endif %}">
+                <a href="#forked_graphs" data-toggle="tab">Forked Graphs <span id="forkedGraphsTotal"
+                                                                               class="badge">{{ forked_graphs.total }}</span></a>
+            </li>
+
             <li class="text-center">
                 <a href="{% url 'upload_graph' %}">Upload New Graph</a>
             </li>
@@ -68,6 +73,10 @@
 
             <div class="tab-pane fade {% if not uid %} in active {% endif %}" id="public_graphs">
                 {% include 'graphs/public_graphs_table.html' %}
+            </div>
+
+            <div class="tab-pane fade {% if not uid %} in active {% endif %}" id="forked_graphs">
+                {% include 'graphs/forked_graphs_table.html' %}
             </div>
 
             <div class="tab-pane fade" id="upload_graph">


### PR DESCRIPTION
## Purpose
This patch fixes #336 - Allow users to fork/clone a graph.
This is an initial commit to the Fork Graph functionality. 


## Approach 

**Add Fork :**
1. Added graphFork table with the following fields - graph_id, parent_graph_id, owner_email. 
2. Forked graph Table is populated in a similar way to Public Graphs.

Forking option is only available for public and shared graphs not owned by the current User.
I have created the Fork REST Api to handle Forking requests. User can send an `add fork` request using the Fork POST method. Graph details and JSON data is passed along with the request body. I am checking for user authentication and allowing only GET and POST requests from the user. 
For saving a fork I am using the following approach :
From the request body I extract and store the ID of the graph as `parent_graph_id`, then I create a new graph using the existing `add_graph` functionality. When a new graph has been created I will insert a record in the _graph_fork_ table with the `graph_id` of the new graph just created and the `parent_graph_id`.

**Populating Index Page tables :**
Forked Graph index page is populated in a way similar to Public Graphs. Index pages of all graphs are populated using the Graph search feature, for example, in case of public graphs parameter `is_public` is passed to the search function. For forked graphs I am using the parameter `is_forked`. I have used this approach because a forked graph can also be considered as an Owned Graph therefore it needs a way to be found using the Graph API's search endpoint.

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

#### Blog Posts
- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.

