### PR TITLE
Layout compatibility feature

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Purpose
+_Describe the problem or feature in addition to a link to the issues._
+
+Example:
+Fixes # .
+
+## Approach
+_How does this change address the problem?_
+
+#### Open Questions and Pre-Merge TODOs
+- [ ] Use github checklists. When solved, check the box and explain the answer.
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons used to solve this problem_
+
+#### Blog Posts
+- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.
+

--- a/api_specifications/api.raml
+++ b/api_specifications/api.raml
@@ -543,6 +543,156 @@ types:
       graph_id: number
       positions_json: string
       style_json: string
+  GraphVersion:
+    description: Graph Version object
+    example: |
+      {
+        "name": "Graph Version 1.0",
+        "owner_email": "user1@example.com",
+        "description": "This is Version 1.0 of Sample Graph",
+        "graph_id": 1,
+        "graph_json": {
+          "elements": {
+            "nodes": [
+              {
+                "position": {
+                  "y": 277.5,
+                  "x": 297.5
+                },
+                "data": {
+                  "k": 0,
+                  "id": "P4314611",
+                  "name": "P4314611",
+                  "label": ""
+                }
+              },
+              {
+                "position": {
+                  "y": 277.5,
+                  "x": 892.5
+                },
+                "data": {
+                  "k": 0,
+                  "id": "P0810711",
+                  "name": "P0810711",
+                  "label": ""
+                }
+              }
+            ],
+            "edges": [
+              {
+                "data": {
+                  "target": "P0810711",
+                  "k": 0,
+                  "source": "P4314611",
+                  "is_directed": 1,
+                  "id": "P4314611-P0810711",
+                  "name": "P4314611-P0810711"
+                },
+                "style": {
+                  "line-color": "blue",
+                  "target-arrow-shape": "triangle",
+                  "source-arrow-color": "yellow",
+                  "width": "12px",
+                  "curve-style": "bezier",
+                  "line-style": "dotted"
+                }
+              }
+            ]
+          },
+          "data": {
+            "description": "Description of graph.. can also point to an image hosted elsewhere",
+            "name": "My first graph",
+            "tags": [
+              "tutorial", "sample"
+            ]
+          }
+        }
+      }
+    properties:
+      name: string
+      owner_email: string
+      description: string
+      graph_id: number
+      graph_json: GraphJSON
+  GraphVersionResponse:
+      description: Graph Version Response object
+      example: |
+        {
+          "name": "Graph Version 1.0",
+          "updated_at": "2017-03-25T15:37:20.728954",
+          "graph_id": 25,
+          "created_at": "2017-03-25T15:37:20.728954",
+          "owner_email": "user1@example.com",
+          "description": "This is Version 1.0 of Sample Graph",
+          "id": 21384,
+          "graph_json": {
+            "elements": {
+              "nodes": [
+                {
+                  "position": {
+                    "y": 277.5,
+                    "x": 297.5
+                  },
+                  "data": {
+                    "k": 0,
+                    "id": "P4314611",
+                    "name": "P4314611",
+                    "label": ""
+                  }
+                },
+                {
+                  "position": {
+                    "y": 277.5,
+                    "x": 892.5
+                  },
+                  "data": {
+                    "k": 0,
+                    "id": "P0810711",
+                    "name": "P0810711",
+                    "label": ""
+                  }
+                }
+              ],
+              "edges": [
+                {
+                  "data": {
+                    "target": "P0810711",
+                    "k": 0,
+                    "source": "P4314611",
+                    "is_directed": 1,
+                    "id": "P4314611-P0810711",
+                    "name": "P4314611-P0810711"
+                  },
+                  "style": {
+                    "line-color": "blue",
+                    "target-arrow-shape": "triangle",
+                    "source-arrow-color": "yellow",
+                    "width": "12px",
+                    "curve-style": "bezier",
+                    "line-style": "dotted"
+                  }
+                }
+              ]
+            },
+            "data": {
+              "description": "Description of graph.. can also point to an image hosted elsewhere",
+              "name": "My first graph",
+              "tags": [
+                "tutorial", "sample"
+              ]
+            }
+          }
+        }
+      properties:
+        id: number
+        name: string
+        owner_email: string
+        graph_id: number
+        graph_json: GraphJSON
+        created_at: string
+        updated_at: string
+        description: string
   Member:
     description: Member Response object
     example: |
@@ -802,6 +952,117 @@ types:
                   example: |
                     {
                       "message": "Successfully deleted layout with id=1068"
+                    }
+            403:
+              description: FORBIDDEN
+              body:
+                application/json:
+                  type: Error
+    /versions:
+      description: APIs to access versions of a specific graph on GraphSpace.
+      displayName: Graph Versions
+      get:
+        description: List all Graph Versions matching query criteria, if provided; otherwise list all Graph Versions.
+        queryParameters:
+          owner_email?: string
+          name?:
+            description: Search for Graph Versions with given name. In order to search for versions with given name as a substring, wrap the name with percentage symbol. For example, %xyz% will search for all versions with xyz in their name.
+            type: string
+          limit?:
+            description: Number of entities to return.
+            default: 20
+            type: number
+          offset?:
+            description: Offset the list of returned entities by this number.
+            default: 0
+            type: number
+          order?:
+            description: Defines the column sort order, can only be 'asc' or 'desc'.
+            type: string
+          sort?:
+            description: Defines which column will be sorted.
+            type: string
+            example: "name"
+        responses:
+          200:
+            description: SUCCESS
+            body:
+              application/json:
+                type: object
+                properties:
+                  total: number
+                  versions: GraphVersionResponse[]
+          400:
+            description: BAD REQUEST
+            body:
+              application/json:
+                type: Error
+          403:
+            description: FORBIDDEN
+            body:
+              application/json:
+                type: Error
+      post:
+          description: Create a new Graph Version.
+          body:
+            application/json:
+              type: GraphVersion
+          responses:
+            201:
+              description: SUCCESS
+              body:
+                application/json:
+                  type: GraphVersionResponse
+            400:
+              description: BAD REQUEST
+              body:
+                application/json:
+                  type: Error
+      /{version_id}:
+        description: APIs to access a specific graph version on GraphSpace.
+        displayName: Graph Version
+        get:
+          description: Get a Graph Version by id
+          responses:
+            200:
+              description: SUCCESS
+              body:
+                application/json:
+                  type: GraphVersionResponse
+            403:
+              description: FORBIDDEN
+              body:
+                application/json:
+                  type: Error
+        put:
+          description: Update a Graph Version by id
+          body:
+            application/json:
+              type: GraphVersion
+          responses:
+            200:
+              description: SUCCESS
+              body:
+                application/json:
+                  type: GraphVersionResponse
+            403:
+              description: FORBIDDEN
+              body:
+                application/json:
+                  type: Error
+        delete:
+          description: Delete a Graph Version by id
+          responses:
+            200:
+              description: SUCCESS
+              body:
+                application/json:
+                  type: object
+                  properties:
+                    message: string
+                  example: |
+                    {
+                      "message": "Successfully deleted graph version with id=21341"
                     }
             403:
               description: FORBIDDEN

--- a/applications/graphs/controllers.py
+++ b/applications/graphs/controllers.py
@@ -586,3 +586,30 @@ def add_edge(request, name=None, head_node_id=None, tail_node_id=None, is_direct
 def delete_edge_by_id(request, edge_id):
 	db.delete_edge(request.db_session, id=edge_id)
 	return
+
+def search_graph_versions(request, graph_id=None, names=None, limit=20, offset=0, order='desc', sort='name'):
+	if sort == 'name':
+		sort_attr = db.GraphVersion.name
+	elif sort == 'update_at':
+		sort_attr = db.GraphVersion.updated_at
+	else:
+		sort_attr = db.GraphVersion.name
+
+	if order == 'desc':
+		orber_by = db.desc(sort_attr)
+	else:
+		orber_by = db.asc(sort_attr)
+
+	## TODO: create a util function to relpace the code parse sort and order parameters. This code is repeated again and again.
+
+	total, graph_versions = db.find_graph_versions(request.db_session,
+	                             names=names,
+	                             graph_id=graph_id,
+	                             limit=limit,
+	                             offset=offset,
+	                             order_by=orber_by)
+
+	return total, graph_versions
+
+def get_graph_version_by_id(request, version_id):
+	return db.get_graph_version_by_id(request.db_session, version_id)

--- a/applications/graphs/controllers.py
+++ b/applications/graphs/controllers.py
@@ -191,8 +191,20 @@ def add_graph(request, name=None, tags=None, is_public=None, graph_json=None, st
 
 	# Construct new graph to add to database
 	new_graph = db.add_graph(request.db_session, name=name, owner_email=owner_email,
-	                         graph_json=json.dumps(G.get_graph_json()), style_json=json.dumps(G.get_style_json()),
 	                         is_public=is_public, default_layout_id=default_layout_id)
+	default_version =  db.add_graph_version(request.db_session, name=name, description='Default Version',
+	                                        owner_email=owner_email, graph_json=json.dumps(G.get_graph_json()),
+	                                        style_json=json.dumps(G.get_style_json()), graph_id=new_graph.id)
+
+	# Add graph_json to new_graph
+	new_graph.__setattr__('graph_json', default_version.graph_json)
+
+	# Add style_json to new_graph
+	new_graph.__setattr__('style_json', default_version.style_json)
+	# Store the index of default version in the graph table (new_graph entry)
+	new_graph.__setattr__('default_version_id',default_version.id)
+	db.set_default_version(request.db_session, new_graph.id, default_version.id)
+
 	# Add graph tags
 	for tag in G.get_tags():
 		add_graph_tag(request, new_graph.id, tag)

--- a/applications/graphs/controllers.py
+++ b/applications/graphs/controllers.py
@@ -650,14 +650,36 @@ def search_graph_versions(request, graph_id=None, names=None, limit=20, offset=0
 
 	return total, graph_versions
 
+
 def get_graph_version_by_id(request, version_id):
 	return db.get_graph_version_by_id(request.db_session, version_id)
+
 
 def add_graph_version(request, name=None, description=None, owner_email=None, graph_json=None, graph_id=None):
 	if name is None or graph_id is None or graph_json is None:
 		raise Exception("Required Parameter is missing!")
 	return db.add_graph_version(request.db_session, name=name, description=description, owner_email=owner_email, graph_json=graph_json, graph_id=graph_id)
 
+
 def delete_graph_version_by_id(request, graph_version_id):
 	db.delete_graph_version(request.db_session, id=graph_version_id)
+	return
+
+
+def get_graph_version_to_layout_status(request, graph_version_id, layout_id):
+	return db.get_graph_version_to_layout_status(request.db_session, graph_version_id, layout_id)
+
+
+def add_graph_version_to_layout_status(request, graph_version_id, layout_id, status=None):
+	if graph_version_id is None or layout_id is None:
+		raise Exception("Required Parameter(s) are missing!")
+	return db.add_graph_version_to_layout_status(request.db_session, graph_version_id=graph_version_id, layout_id=layout_id, status=status)
+
+
+def update_graph_version_to_layout_status(request, graph_version_id, layout_id=None, status=None):
+	return db.update_graph_version_to_layout_status(request.db_session, graph_version_id, layout_id, status)
+
+
+def delete_graph_version_to_layout_status(request, graph_version_id, layout_id):
+	db.delete_graph_version_to_layout_status(request.db_session, graph_version_id=graph_version_id, layout_id=layout_id)
 	return

--- a/applications/graphs/controllers.py
+++ b/applications/graphs/controllers.py
@@ -203,7 +203,7 @@ def add_graph(request, name=None, tags=None, is_public=None, graph_json=None, st
 	new_graph.__setattr__('style_json', default_version.style_json)
 	# Store the index of default version in the graph table (new_graph entry)
 	new_graph.__setattr__('default_version_id',default_version.id)
-	db.set_default_version(request.db_session, new_graph.id, default_version.id)
+	#db.set_default_version(request.db_session, new_graph.id, default_version.id)
 
 	# Add graph tags
 	for tag in G.get_tags():

--- a/applications/graphs/controllers.py
+++ b/applications/graphs/controllers.py
@@ -613,3 +613,8 @@ def search_graph_versions(request, graph_id=None, names=None, limit=20, offset=0
 
 def get_graph_version_by_id(request, version_id):
 	return db.get_graph_version_by_id(request.db_session, version_id)
+
+def add_graph_version(request, name=None, description=None, owner_email=None, graph_json=None, graph_id=None):
+	if name is None or graph_id is None or graph_json is None:
+		raise Exception("Required Parameter is missing!")
+	return db.add_graph_version(request.db_session, name=name, description=description, owner_email=owner_email, graph_json=graph_json, graph_id=graph_id)

--- a/applications/graphs/controllers.py
+++ b/applications/graphs/controllers.py
@@ -618,3 +618,7 @@ def add_graph_version(request, name=None, description=None, owner_email=None, gr
 	if name is None or graph_id is None or graph_json is None:
 		raise Exception("Required Parameter is missing!")
 	return db.add_graph_version(request.db_session, name=name, description=description, owner_email=owner_email, graph_json=graph_json, graph_id=graph_id)
+
+def delete_graph_version_by_id(request, graph_version_id):
+	db.delete_graph_version(request.db_session, id=graph_version_id)
+	return

--- a/applications/graphs/dal.py
+++ b/applications/graphs/dal.py
@@ -491,3 +491,9 @@ def add_graph_version(db_session, graph_id, name, graph_json, owner_email, descr
 	graph_version = GraphVersion(name=name, graph_id=graph_id, graph_json=graph_json, owner_email=owner_email, description=description)
 	db_session.add(graph_version)
 	return graph_version
+
+@with_session
+def delete_graph_version(db_session, id):
+    graph_version = db_session.query(GraphVersion).filter(GraphVersion.id == id).one_or_none()
+    db_session.delete(graph_version)
+    return graph_version

--- a/applications/graphs/dal.py
+++ b/applications/graphs/dal.py
@@ -18,8 +18,8 @@ def get_edges(db_session, edges, order=desc(Edge.updated_at), page=0, page_size=
 
 @with_session
 def get_graphs_by_edges_and_nodes_and_names(db_session, group_ids=None, names=None, nodes=None, edges=None, tags=None,
-                                            order=desc(Graph.updated_at), page=0, page_size=10, partial_matching=False,
-                                            owner_email=None, is_public=None):
+											order=desc(Graph.updated_at), page=0, page_size=10, partial_matching=False,
+											owner_email=None, is_public=None):
 	query = db_session.query(Graph)
 
 	edges = [] if edges is None else edges
@@ -47,7 +47,7 @@ def get_graphs_by_edges_and_nodes_and_names(db_session, group_ids=None, names=No
 	nodes_filter_group = [Node.label.ilike(node) for node in nodes]
 	nodes_filter_group.extend([Node.name.ilike(node) for node in nodes])
 	edges_filter_group = [and_(Edge.head_node.has(Node.name.ilike(u)), Edge.tail_node.has(Node.name.ilike(v))) for u, v
-	                      in edges]
+						  in edges]
 	edges_filter_group.extend(
 		[and_(Edge.tail_node.has(Node.name.ilike(u)), Edge.head_node.has(Node.name.ilike(v))) for u, v in edges])
 	edges_filter_group.extend(
@@ -82,7 +82,7 @@ def get_graphs_by_edges_and_nodes_and_names(db_session, group_ids=None, names=No
 @with_session
 def add_graph(db_session, name, owner_email, is_public=0, default_layout_id=None):
 	graph = Graph(name=name, owner_email=owner_email,  is_public=is_public,
-	              default_layout_id=default_layout_id)
+				  default_layout_id=default_layout_id)
 	db_session.add(graph)
 	return graph
 
@@ -128,13 +128,14 @@ def delete_graph(db_session, id):
 @with_session
 def get_graph_by_id(db_session, id):
 	query = db_session.query(Graph).filter(Graph.id == id)
+	query.options(joinedload('graph_versions')).filter(GraphVersion.id==Graph.default_version_id)
 	return query.one_or_none()
 
 
 @with_session
 def find_graphs(db_session, owner_email=None, group_ids=None, graph_ids=None, is_public=None, names=None, nodes=None,
-                edges=None,
-                tags=None, limit=None, offset=None, order_by=desc(Graph.updated_at)):
+				edges=None,
+				tags=None, limit=None, offset=None, order_by=desc(Graph.updated_at)):
 	query = db_session.query(Graph)
 	#query = query.options(defer("graph_json")).options(defer("style_json"))
 
@@ -225,10 +226,10 @@ def add_edge(db_session, graph_id, head_node_id, tail_node_id, name, is_directed
 	tail_node = get_node_by_id(db_session, tail_node_id)
 
 	edge = Edge(name=name, graph_id=graph_id,
-	            head_node_id=head_node_id, tail_node_id=tail_node_id,
-	            head_node_name=head_node.name, tail_node_name=tail_node.name,
-	            head_node_label=head_node.label, tail_node_label=tail_node.label,
-	            is_directed=is_directed)
+				head_node_id=head_node_id, tail_node_id=tail_node_id,
+				head_node_name=head_node.name, tail_node_name=tail_node.name,
+				head_node_label=head_node.label, tail_node_label=tail_node.label,
+				is_directed=is_directed)
 	db_session.add(edge)
 	return edge
 
@@ -322,7 +323,7 @@ def delete_graph_to_group(db_session, group_id, graph_id):
 
 @with_session
 def find_layouts(db_session, owner_email=None, is_shared=None, name=None, graph_id=None, limit=None, offset=None,
-                 order_by=desc(Layout.updated_at)):
+				 order_by=desc(Layout.updated_at)):
 	query = db_session.query(Layout)
 
 	if order_by is not None:
@@ -372,7 +373,7 @@ def add_layout(db_session, owner_email, name, graph_id, is_shared, style_json, p
 
 	"""
 	layout = Layout(owner_email=owner_email, name=name, graph_id=graph_id, is_shared=is_shared, style_json=style_json,
-	                positions_json=positions_json)
+					positions_json=positions_json)
 	db_session.add(layout)
 	return layout
 
@@ -413,7 +414,7 @@ def delete_layout(db_session, id):
 
 @with_session
 def find_nodes(db_session, labels=None, names=None, graph_id=None, limit=None, offset=None,
-               order_by=desc(Node.updated_at)):
+			   order_by=desc(Node.updated_at)):
 	query = db_session.query(Node)
 
 	if graph_id is not None:
@@ -438,7 +439,7 @@ def find_nodes(db_session, labels=None, names=None, graph_id=None, limit=None, o
 
 @with_session
 def find_edges(db_session, is_directed=None, names=None, edges=None, graph_id=None, limit=None, offset=None,
-               order_by=desc(Node.updated_at)):
+			   order_by=desc(Node.updated_at)):
 	query = db_session.query(Edge)
 
 	if graph_id is not None:
@@ -469,7 +470,18 @@ def find_edges(db_session, is_directed=None, names=None, edges=None, graph_id=No
 
 @with_session
 def find_graph_versions(db_session, names=None, graph_id=None, limit=None, offset=None,
-               order_by=desc(GraphVersion.updated_at)):
+			   order_by=desc(GraphVersion.updated_at)):
+	"""
+	Find graph version by Graph ID.
+	:param db_session: Database session.
+	:param graph_id: Unique ID of the graph
+	:param name - Name of the graph version
+	:param limit - Number of entities to return. Default value is 20.
+	:param offset - Offset the list of returned entities by this number. Default value is 0.
+	:param order_by - Defines which column the results will be sorted by.
+	:return: Total, Graph Versions
+	"""
+
 	query = db_session.query(GraphVersion)
 
 	if graph_id is not None:
@@ -492,22 +504,55 @@ def find_graph_versions(db_session, names=None, graph_id=None, limit=None, offse
 
 @with_session
 def get_graph_version_by_id(db_session, id):
+	"""
+	Get graph version by ID.
+	:param db_session: Database session.
+	:param id: Unique ID of the graph version
+	:return: Graph Version if id exists else None
+	"""
 	return db_session.query(GraphVersion).filter(GraphVersion.id == id).one_or_none()
 
 @with_session
-def add_graph_version(db_session, graph_id, name, graph_json, owner_email, style_json=None, description=None, is_default=0):
+def add_graph_version(db_session, graph_id, name, graph_json, owner_email, style_json=None, description=None, is_default=None):
+	"""
+	Get graph version by ID.
+	:param db_session: Database session.
+	:param graph_id: Unique ID of the graph
+	:param name - Name of the graph version
+	:param graph_json - positions_json of the layouts.
+	:param owner_email - ID of user who owns the graph
+	:param style_json - style_json of the layouts.
+	:param description - ID of the graph the layout belongs to.
+	:param is_default - Set this graph_version as the default version of the graph
+	:return: Graph Version if id exists else None
+	"""
 	graph_version = GraphVersion(name=name, graph_id=graph_id, graph_json=graph_json, style_json=style_json, owner_email=owner_email, description=description)
+	if is_default is not None:
+		set_default_version(db_session, graph_id, graph_version.id)
 	db_session.add(graph_version)
 	return graph_version
 
 @with_session
 def delete_graph_version(db_session, id):
-    graph_version = db_session.query(GraphVersion).filter(GraphVersion.id == id).one_or_none()
-    db_session.delete(graph_version)
-    return graph_version
+	"""
+	Delete graph version.
+	:param db_session: Database session.
+	:param id: Unique ID of the graph version
+	:return: None
+	"""
+	graph_version = db_session.query(GraphVersion).filter(GraphVersion.id == id).one_or_none()
+	db_session.delete(graph_version)
+	return
 
 @with_session
 def set_default_version(db_session, graph_id, default_version_id):
+	"""
+	Set the default graph version.
+	:param db_session: Database session.
+	:param graph_id: Unique ID of the graph
+	:param default_version_id: Unique ID of the graph version
+	:return: None
+	"""
 	graph = db_session.query(Graph).filter(Graph.id == graph_id).one_or_none()
 	setattr(graph, 'default_version_id', default_version_id)
-	return graph
+	return

--- a/applications/graphs/dal.py
+++ b/applications/graphs/dal.py
@@ -80,8 +80,8 @@ def get_graphs_by_edges_and_nodes_and_names(db_session, group_ids=None, names=No
 
 
 @with_session
-def add_graph(db_session, name, owner_email, graph_json, style_json, is_public=0, default_layout_id=None):
-	graph = Graph(name=name, owner_email=owner_email, graph_json=graph_json, style_json=style_json, is_public=is_public,
+def add_graph(db_session, name, owner_email, is_public=0, default_layout_id=None):
+	graph = Graph(name=name, owner_email=owner_email,  is_public=is_public,
 	              default_layout_id=default_layout_id)
 	db_session.add(graph)
 	return graph
@@ -487,8 +487,8 @@ def get_graph_version_by_id(db_session, id):
 	return db_session.query(GraphVersion).filter(GraphVersion.id == id).one_or_none()
 
 @with_session
-def add_graph_version(db_session, graph_id, name, graph_json, owner_email, description=None):
-	graph_version = GraphVersion(name=name, graph_id=graph_id, graph_json=graph_json, owner_email=owner_email, description=description)
+def add_graph_version(db_session, graph_id, name, graph_json, owner_email, style_json=None, description=None, is_default=0):
+	graph_version = GraphVersion(name=name, graph_id=graph_id, graph_json=graph_json, style_json=style_json, owner_email=owner_email, description=description)
 	db_session.add(graph_version)
 	return graph_version
 
@@ -497,3 +497,9 @@ def delete_graph_version(db_session, id):
     graph_version = db_session.query(GraphVersion).filter(GraphVersion.id == id).one_or_none()
     db_session.delete(graph_version)
     return graph_version
+
+@with_session
+def set_default_version(db_session, graph_id, default_version_id):
+	graph = db_session.query(Graph).filter(Graph.id == graph_id).one_or_none()
+	setattr(graph, 'default_version_id', default_version_id)
+	return graph

--- a/applications/graphs/dal.py
+++ b/applications/graphs/dal.py
@@ -485,3 +485,9 @@ def find_graph_versions(db_session, names=None, graph_id=None, limit=None, offse
 @with_session
 def get_graph_version_by_id(db_session, id):
 	return db_session.query(GraphVersion).filter(GraphVersion.id == id).one_or_none()
+
+@with_session
+def add_graph_version(db_session, graph_id, name, graph_json, owner_email, description=None):
+	graph_version = GraphVersion(name=name, graph_id=graph_id, graph_json=graph_json, owner_email=owner_email, description=description)
+	db_session.add(graph_version)
+	return graph_version

--- a/applications/graphs/dal.py
+++ b/applications/graphs/dal.py
@@ -458,3 +458,30 @@ def find_edges(db_session, is_directed=None, names=None, edges=None, graph_id=No
 		query = query.limit(limit).offset(offset)
 
 	return total, query.all()
+
+@with_session
+def find_graph_versions(db_session, names=None, graph_id=None, limit=None, offset=None,
+               order_by=desc(GraphVersion.updated_at)):
+	query = db_session.query(GraphVersion)
+
+	if graph_id is not None:
+		query = query.filter(GraphVersion.graph_id == graph_id)
+
+	names = [] if names is None else names
+	if len(names) > 0:
+		query = query.filter(
+			or_(*([GraphVersion.name.ilike(name) for name in names])))
+
+	total = query.count()
+
+	if order_by is not None:
+		query = query.order_by(order_by)
+
+	if offset is not None and limit is not None:
+		query = query.limit(limit).offset(offset)
+
+	return total, query.all()
+
+@with_session
+def get_graph_version_by_id(db_session, id):
+	return db_session.query(GraphVersion).filter(GraphVersion.id == id).one_or_none()

--- a/applications/graphs/models.py
+++ b/applications/graphs/models.py
@@ -17,8 +17,10 @@ class Graph(IDMixin, TimeStampMixin, Base):
 
 	name = Column(String, nullable=False)
 	owner_email = Column(String, ForeignKey('user.email', ondelete="CASCADE", onupdate="CASCADE"), nullable=False)
-	graph_json = Column(String, nullable=False)
-	style_json = Column(String, nullable=False)
+	#graph_json = Column(String, nullable=False)
+	#style_json = Column(String, nullable=False)
+	default_version_id = Column(Integer, ForeignKey('graph_version.id', ondelete="CASCADE", onupdate="CASCADE"),
+	                           nullable=True)
 	is_public = Column(Integer, nullable=False, default=0)
 	default_layout_id = Column(Integer, ForeignKey('layout.id', ondelete="CASCADE", onupdate="CASCADE"),
 	                           nullable=True)
@@ -290,6 +292,7 @@ class GraphVersion(IDMixin, TimeStampMixin, Base):
 	graph_id = Column(Integer, ForeignKey('graph.id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
 	owner_email = Column(String, ForeignKey('user.email', ondelete="CASCADE", onupdate="CASCADE"), nullable=False)
 	graph_json = Column(String, nullable=False)
+	style_json = Column(String, nullable=False)
 	description = Column(String, nullable=True)
 
 	graph = relationship("Graph", foreign_keys=[graph_id], back_populates="graph_version", uselist=False)

--- a/applications/graphs/models.py
+++ b/applications/graphs/models.py
@@ -295,12 +295,22 @@ class GraphVersion(IDMixin, TimeStampMixin, Base):
 	graph = relationship("Graph", foreign_keys=[graph_id], back_populates="graph_version", uselist=False)
 
 	def serialize(cls, **kwargs):
-		return {
-			'id': cls.id,
-			'name': cls.name,
-			'description': cls.description,
-			'graph_json' : cls.graph_json,
-			'creator': cls.owner_email,
-			'created_at': cls.created_at.isoformat(),
-			'updated_at': cls.updated_at.isoformat()
-		}
+		if 'summary' in kwargs and kwargs['summary']:
+			return {
+				'id': cls.id,
+				'name': cls.name,
+				'description': cls.description,
+				'creator': cls.owner_email,
+				'created_at': cls.created_at.isoformat(),
+				'updated_at': cls.updated_at.isoformat()
+			}
+		else :
+			return {
+				'id': cls.id,
+				'name': cls.name,
+				'description': cls.description,
+				'graph_json': cls.graph_json,
+				'creator': cls.owner_email,
+				'created_at': cls.created_at.isoformat(),
+				'updated_at': cls.updated_at.isoformat()
+			}

--- a/applications/graphs/models.py
+++ b/applications/graphs/models.py
@@ -289,6 +289,7 @@ class GraphToTag(TimeStampMixin, Base):
 		args = cls.constraints + cls.indices
 		return args
 
+
 class GraphVersion(IDMixin, TimeStampMixin, Base):
 	__tablename__ = 'graph_version'
 
@@ -326,7 +327,7 @@ class GraphVersion(IDMixin, TimeStampMixin, Base):
 				'created_at': cls.created_at.isoformat(),
 				'updated_at': cls.updated_at.isoformat()
 			}
-		else :
+		else:
 			return {
 				'id': cls.id,
 				'name': cls.name,
@@ -336,3 +337,24 @@ class GraphVersion(IDMixin, TimeStampMixin, Base):
 				'created_at': cls.created_at.isoformat(),
 				'updated_at': cls.updated_at.isoformat()
 			}
+
+
+class LayoutToGraphVersion(IDMixin, TimeStampMixin, Base):
+	__tablename__ = 'layout_to_graph_version'
+
+	layout_id = Column(Integer, ForeignKey('layout.id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
+	graph_version_id = Column(Integer, ForeignKey('graph_version.id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
+	status = Column(String, nullable=True)
+
+	constraints = (
+		UniqueConstraint('layout_id', 'graph_version_id', 'compatibility_status', name='layout_uc_layout_id_graph_version_id_compatibility_status')
+	)
+
+	def serialize(cls, **kwargs):
+		return {
+			'graph_version_id': cls.graph_version_id,
+			'layout_id': cls.layout_id,
+			'status': cls.status,
+			'created_at': cls.created_at.isoformat(),
+			'updated_at': cls.updated_at.isoformat()
+		}

--- a/applications/graphs/models.py
+++ b/applications/graphs/models.py
@@ -300,8 +300,8 @@ class GraphVersion(IDMixin, TimeStampMixin, Base):
 	description = Column(String, nullable=True)
 	graph = relationship("Graph", foreign_keys=[graph_id], back_populates="graph_versions", uselist=False)
 	default_version_graph = relationship("Graph", foreign_keys="Graph.default_version_id",
-										back_populates="default_version", cascade="all,  delete-orphan",
-										uselist=False)
+	                                     back_populates="default_version", cascade="all,  delete-orphan",
+	                                     uselist=False)
 	constraints = (
 		UniqueConstraint('graph_id', 'name', name='_graph_version_uc_graph_id_name'),
 		UniqueConstraint('id', 'name', name='_graph_version_uc_id_name'),

--- a/applications/graphs/models.py
+++ b/applications/graphs/models.py
@@ -34,8 +34,10 @@ class Graph(IDMixin, TimeStampMixin, Base):
 	edges = relationship("Edge", back_populates="graph", cascade="all, delete-orphan")
 	nodes = relationship("Node", back_populates="graph", cascade="all, delete-orphan")
 
-	graph_version = relationship("GraphVersion", foreign_keys="GraphVersion.graph_id", back_populates="graph",
-	                             cascade="all, delete-orphan")
+	default_version = relationship("GraphVersion", foreign_keys=[default_version_id], back_populates="default_version_graph",
+								  uselist=False)
+	graph_versions = relationship("GraphVersion", foreign_keys="GraphVersion.graph_id", back_populates="graph",
+								  passive_deletes=True)
 
 	groups = association_proxy('shared_with_groups', 'group')
 	tags = association_proxy('graph_tags', 'tag')
@@ -61,6 +63,7 @@ class Graph(IDMixin, TimeStampMixin, Base):
 				'is_public': cls.is_public,
 				'tags': [tag.name for tag in cls.tags],
 				'default_layout_id': cls.default_layout_id,
+				'default_version_id': cls.default_version_id,
 				'created_at': cls.created_at.isoformat(),
 				'updated_at': cls.updated_at.isoformat()
 			}
@@ -69,11 +72,12 @@ class Graph(IDMixin, TimeStampMixin, Base):
 				'id': cls.id,
 				'owner_email': cls.owner_email,
 				'name': cls.name,
-				'graph_json': json.loads(cls.graph_json),
-				'style_json': json.loads(cls.style_json),
+				'graph_json': json.loads(cls.default_version.graph_json),
+				'style_json': json.loads(cls.default_version.style_json),
 				'is_public': cls.is_public,
 				'tags': [tag.name for tag in cls.tags],
 				'default_layout_id': cls.default_layout_id,
+				'default_version_id': cls.default_version_id,
 				'created_at': cls.created_at.isoformat(),
 				'updated_at': cls.updated_at.isoformat()
 			}
@@ -288,14 +292,29 @@ class GraphToTag(TimeStampMixin, Base):
 class GraphVersion(IDMixin, TimeStampMixin, Base):
 	__tablename__ = 'graph_version'
 
-	name = Column(String, nullable=False, unique=True)
-	graph_id = Column(Integer, ForeignKey('graph.id', ondelete="CASCADE", onupdate="CASCADE"), primary_key=True)
+	name = Column(String, nullable=False)
+	graph_id = Column(Integer, ForeignKey('graph.id', ondelete="CASCADE", onupdate="CASCADE"), nullable=False)
 	owner_email = Column(String, ForeignKey('user.email', ondelete="CASCADE", onupdate="CASCADE"), nullable=False)
 	graph_json = Column(String, nullable=False)
 	style_json = Column(String, nullable=False)
 	description = Column(String, nullable=True)
+	graph = relationship("Graph", foreign_keys=[graph_id], back_populates="graph_versions", uselist=False)
+	default_version_graph = relationship("Graph", foreign_keys="Graph.default_version_id",
+										back_populates="default_version", cascade="all,  delete-orphan",
+										uselist=False)
+	constraints = (
+		UniqueConstraint('graph_id', 'name', name='_graph_version_uc_graph_id_name'),
+		UniqueConstraint('id', 'name', name='_graph_version_uc_id_name'),
+	)
 
-	graph = relationship("Graph", foreign_keys=[graph_id], back_populates="graph_version", uselist=False)
+	indices = (
+		Index('graph_version_idx_name', text("name gin_trgm_ops"), postgresql_using="gin"),
+	)
+
+	@declared_attr
+	def __table_args__(cls):
+		args = cls.constraints + cls.indices
+		return args
 
 	def serialize(cls, **kwargs):
 		if 'summary' in kwargs and kwargs['summary']:

--- a/applications/graphs/tests.py
+++ b/applications/graphs/tests.py
@@ -37,7 +37,7 @@ class GraphModelTestCase(TestCase):
 
 		# Create
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		self.session.commit()
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.assertEqual(graph1.name, 'graph1')
@@ -61,23 +61,23 @@ class GraphModelTestCase(TestCase):
 	def test_owner_email_fkey_constraint(self):
 
 		with self.assertRaises(IntegrityError):
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			self.session.commit()
 
 	def test_default_layout_id_fkey_constraint(self):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0, default_layout_id=1))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0, default_layout_id=1))
 			self.session.commit()
 
 	def test_name_owner_email_uc_constraint(self):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			self.session.commit()
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=1))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=1))
 			self.session.commit()
 
 	def test_cascade_on_user_delete(self):
@@ -85,7 +85,7 @@ class GraphModelTestCase(TestCase):
 		On deleting user row, the corresponding row in graph table should also be deleted.
 		"""
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		self.session.commit()
 
 		owner = self.session.query(User).filter(User.email == 'owner@example.com').one_or_none()
@@ -101,7 +101,7 @@ class GraphModelTestCase(TestCase):
 		On deleting user row, the corresponding row in graph table should also be updated
 		"""
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		self.session.commit()
 		graph1 = self.session.query(Graph).filter(and_(Graph.owner_email == 'owner@example.com', Graph.name == 'graph1')).one_or_none()
 
@@ -115,7 +115,7 @@ class GraphModelTestCase(TestCase):
 
 	def test_owner_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		self.session.commit()
 
 		graph1 = self.session.query(Graph).filter(and_(Graph.owner_email == 'owner@example.com', Graph.name == 'graph1')).one_or_none()
@@ -125,7 +125,7 @@ class GraphModelTestCase(TestCase):
 
 	def test_nodes_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source1'))
 		self.session.commit()
@@ -140,7 +140,7 @@ class GraphModelTestCase(TestCase):
 
 	def test_edges_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -154,9 +154,9 @@ class GraphModelTestCase(TestCase):
 
 	def test_layouts_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
-		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}'))
 		self.session.commit()
 
 		layout1 = self.session.query(Layout).filter(Layout.name == 'layout1').one_or_none()
@@ -165,9 +165,9 @@ class GraphModelTestCase(TestCase):
 
 	def test_default_layout_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
-		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 		self.session.commit()
 
 		layout1 = self.session.query(Layout).filter(Layout.name == 'layout1').one_or_none()
@@ -188,7 +188,7 @@ class GraphModelTestCase(TestCase):
 			Group.owner_email == 'owner@example.com', Group.name == 'group1')).one_or_none()
 
 		self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
 		self.session.commit()
@@ -197,7 +197,7 @@ class GraphModelTestCase(TestCase):
 
 	def test_tags_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 		self.session.add(GraphTag(name='tag1'))
@@ -235,7 +235,7 @@ class NodeModelTestCase(TestCase):
 
 		# Create
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -272,7 +272,7 @@ class NodeModelTestCase(TestCase):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.add(Node(graph_id=graph1.id, name='source', label='source1'))
 			self.session.add(Node(graph_id=graph1.id, name='source', label='source2'))
@@ -283,7 +283,7 @@ class NodeModelTestCase(TestCase):
 		On deleting user row, the corresponding row in node table should also be deleted.
 		"""
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source1'))
 		self.session.commit()
@@ -302,7 +302,7 @@ class NodeModelTestCase(TestCase):
 		On deleting graph row, the corresponding row in node table should also be deleted.
 		"""
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source1'))
 		self.session.commit()
@@ -317,7 +317,7 @@ class NodeModelTestCase(TestCase):
 
 	def test_graph_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source1'))
 		self.session.commit()
@@ -329,7 +329,7 @@ class NodeModelTestCase(TestCase):
 
 	def test_source_edges_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -345,7 +345,7 @@ class NodeModelTestCase(TestCase):
 
 	def test_target_edges_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -388,7 +388,7 @@ class EdgeModelTestCase(TestCase):
 
 		# Create
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -419,7 +419,7 @@ class EdgeModelTestCase(TestCase):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 			self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -435,7 +435,7 @@ class EdgeModelTestCase(TestCase):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 			self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -451,7 +451,7 @@ class EdgeModelTestCase(TestCase):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 			self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -467,7 +467,7 @@ class EdgeModelTestCase(TestCase):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 			self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -481,7 +481,7 @@ class EdgeModelTestCase(TestCase):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 			self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -496,7 +496,7 @@ class EdgeModelTestCase(TestCase):
 		On deleting user row, the corresponding row in edge table should also be deleted.
 		"""
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -519,7 +519,7 @@ class EdgeModelTestCase(TestCase):
 		On deleting graph row, the corresponding row in edge table should also be deleted.
 		"""
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -541,7 +541,7 @@ class EdgeModelTestCase(TestCase):
 		On deleting node row, the corresponding row in edge table should also be deleted.
 		"""
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -560,7 +560,7 @@ class EdgeModelTestCase(TestCase):
 
 	def test_graph_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -574,7 +574,7 @@ class EdgeModelTestCase(TestCase):
 
 	def test_head_node_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -591,7 +591,7 @@ class EdgeModelTestCase(TestCase):
 
 	def test_tail_node_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(Node(graph_id=graph1.id, name='source', label='source'))
 		self.session.add(Node(graph_id=graph1.id, name='target', label='target'))
@@ -644,7 +644,7 @@ class GroupToGraphModelTestCase(TestCase):
 		self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
 		group2user1 = self.session.query(GroupToUser).filter(and_(GroupToUser.user_id == member.id, GroupToUser.group_id == group1.id)).one_or_none()
 
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 		self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
@@ -676,7 +676,7 @@ class GroupToGraphModelTestCase(TestCase):
 			self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
 			group2user1 = self.session.query(GroupToUser).filter(and_(GroupToUser.user_id == member.id, GroupToUser.group_id == group1.id)).one_or_none()
 
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.delete(graph1)
 			self.session.commit()
@@ -700,7 +700,7 @@ class GroupToGraphModelTestCase(TestCase):
 			self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
 			group2user1 = self.session.query(GroupToUser).filter(and_(GroupToUser.user_id == member.id, GroupToUser.group_id == group1.id)).one_or_none()
 
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.delete(group1)
 			self.session.commit()
@@ -723,7 +723,7 @@ class GroupToGraphModelTestCase(TestCase):
 			self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
 			group2user1 = self.session.query(GroupToUser).filter(and_(GroupToUser.user_id == member.id, GroupToUser.group_id == group1.id)).one_or_none()
 
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
 			self.session.commit()
@@ -745,7 +745,7 @@ class GroupToGraphModelTestCase(TestCase):
 		self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
 		group2user1 = self.session.query(GroupToUser).filter(and_(GroupToUser.user_id == member.id, GroupToUser.group_id == group1.id)).one_or_none()
 
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
 		self.session.commit()
@@ -777,7 +777,7 @@ class GroupToGraphModelTestCase(TestCase):
 		self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
 		group2user1 = self.session.query(GroupToUser).filter(and_(GroupToUser.user_id == member.id, GroupToUser.group_id == group1.id)).one_or_none()
 
-		self.session.add(Graph(name='graph1', owner_email='member@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='member@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'member@example.com').one_or_none()
 		self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
 		self.session.commit()
@@ -808,7 +808,7 @@ class GroupToGraphModelTestCase(TestCase):
 		self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
 		self.session.add(GroupToUser(user_id=graph_owner.id, group_id=group1.id))
 
-		self.session.add(Graph(name='graph1', owner_email='graph_owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='graph_owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'graph_owner@example.com').one_or_none()
 		self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
 		self.session.commit()
@@ -836,7 +836,7 @@ class GroupToGraphModelTestCase(TestCase):
 		self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
 		group2user1 = self.session.query(GroupToUser).filter(and_(GroupToUser.user_id == member.id, GroupToUser.group_id == group1.id)).one_or_none()
 
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
 		self.session.commit()
@@ -865,7 +865,7 @@ class GroupToGraphModelTestCase(TestCase):
 		self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
 		group2user1 = self.session.query(GroupToUser).filter(and_(GroupToUser.user_id == member.id, GroupToUser.group_id == group1.id)).one_or_none()
 
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
 		self.session.commit()
@@ -891,7 +891,7 @@ class GroupToGraphModelTestCase(TestCase):
 			Group.owner_email == 'owner@example.com', Group.name == 'group1')).one_or_none()
 
 		self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
 		self.session.commit()
@@ -909,7 +909,7 @@ class GroupToGraphModelTestCase(TestCase):
 			Group.owner_email == 'owner@example.com', Group.name == 'group1')).one_or_none()
 
 		self.session.add(GroupToUser(user_id=member.id, group_id=group1.id))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 		self.session.add(GroupToGraph(graph_id=graph1.id, group_id=group1.id))
 		self.session.commit()
@@ -977,7 +977,7 @@ class GraphTagModelTestCase(TestCase):
 
 	def test_graphs_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 		self.session.add(GraphTag(name='tag1'))
@@ -1016,7 +1016,7 @@ class GraphToTagModelTestCase(TestCase):
 		# Create
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
 
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 		self.session.add(GraphTag(name='tag1'))
@@ -1040,7 +1040,7 @@ class GraphToTagModelTestCase(TestCase):
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
 
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 			self.session.add(GraphTag(name='tag1'))
@@ -1058,7 +1058,7 @@ class GraphToTagModelTestCase(TestCase):
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
 
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 			self.session.add(GraphTag(name='tag1'))
@@ -1074,7 +1074,7 @@ class GraphToTagModelTestCase(TestCase):
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
 
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 			self.session.add(GraphTag(name='tag1'))
@@ -1093,7 +1093,7 @@ class GraphToTagModelTestCase(TestCase):
 
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
 
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 		self.session.add(GraphTag(name='tag1'))
@@ -1117,7 +1117,7 @@ class GraphToTagModelTestCase(TestCase):
 	def test_cascade_on_tag_delete(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
 
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 		self.session.add(GraphTag(name='tag1'))
@@ -1142,7 +1142,7 @@ class GraphToTagModelTestCase(TestCase):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
 		owner = self.session.query(User).filter(User.email == 'owner@example.com').one_or_none()
 
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 		self.session.add(GraphTag(name='tag1'))
@@ -1166,7 +1166,7 @@ class GraphToTagModelTestCase(TestCase):
 	def test_graph_relationship(self):
 
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 		self.session.add(GraphTag(name='tag1'))
@@ -1179,7 +1179,7 @@ class GraphToTagModelTestCase(TestCase):
 
 	def test_tag_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 
 		self.session.add(GraphTag(name='tag1'))
@@ -1219,9 +1219,9 @@ class LayoutModelTestCase(TestCase):
 
 		# Create
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
-		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 		self.session.commit()
 		layout1 = self.session.query(Layout).filter(Layout.owner_email == 'owner@example.com').one_or_none()
 
@@ -1247,36 +1247,36 @@ class LayoutModelTestCase(TestCase):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.delete(graph1)
 			self.session.commit()
 
-			self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+			self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 			self.session.commit()
 
 	def test_owner_email_fkey_constraint(self):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			owner = self.session.query(User).filter(User.email == 'owner@example.com').one_or_none()
 			self.session.delete(owner)
 			self.session.commit()
 
-			self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+			self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 			self.session.commit()
 
 	def test_name_graph_id_owner_email_uc_constraint(self):
 
 		with self.assertRaises(IntegrityError):
 			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-			self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+			self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 			graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
 			self.session.commit()
 
-			self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+			self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 			self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{"a": "a"}', is_public=1, is_shared=1, original_json='{"a": "a"}'))
 			self.session.commit()
 
@@ -1285,9 +1285,9 @@ class LayoutModelTestCase(TestCase):
 		On deleting user row, the corresponding row in node table should also be deleted.
 		"""
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
-		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 		self.session.commit()
 
 		owner = self.session.query(User).filter(User.email == 'owner@example.com').one_or_none()
@@ -1304,9 +1304,9 @@ class LayoutModelTestCase(TestCase):
 		On deleting graph row, the corresponding row in node table should also be deleted.
 		"""
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
-		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 		self.session.commit()
 
 		self.session.delete(graph1)
@@ -1319,9 +1319,9 @@ class LayoutModelTestCase(TestCase):
 
 	def test_graph_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
-		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 		self.session.commit()
 
 		layout1 = self.session.query(Layout).filter(Layout.name == 'layout1').one_or_none()
@@ -1330,9 +1330,9 @@ class LayoutModelTestCase(TestCase):
 
 	def test_owner_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
-		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 		self.session.commit()
 
 		owner = self.session.query(User).filter(User.email == 'owner@example.com').one_or_none()
@@ -1342,9 +1342,9 @@ class LayoutModelTestCase(TestCase):
 
 	def test_default_layout_graph_relationship(self):
 		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
-		self.session.add(Graph(name='graph1', owner_email='owner@example.com', json='{}', is_public=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
 		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
-		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com', json='{}', is_public=0, is_shared=0, original_json='{}'))
+		self.session.add(Layout(graph_id=graph1.id, name='layout1', owner_email='owner@example.com',   is_shared=0, original_json='{}', positions_json='{}', style_json='{}'))
 		self.session.commit()
 
 		layout1 = self.session.query(Layout).filter(Layout.name == 'layout1').one_or_none()
@@ -1355,6 +1355,168 @@ class LayoutModelTestCase(TestCase):
 
 		self.assertEqual(layout1.default_layout_graph.id, graph1.id)
 
+
+class GraphVersionModelTestCase(TestCase):
+	def setUp(self):
+		db = Database()
+		# connect to the database
+		self.connection = db.engine.connect()
+		# begin a non-ORM transaction
+		self.trans = self.connection.begin()
+		# bind an individual Session to the connection
+		self.session = Session(bind=self.connection)
+
+	def tearDown(self):
+		self.session.close()
+
+		# rollback - everything that happened with the
+		# Session above (including calls to commit())
+		# is rolled back.
+		self.trans.rollback()
+
+		# return connection to the Engine
+		self.connection.close()
+
+	def test_crud_operation(self):
+		"""
+		Basic CRUD (Create, Retrieve, Update, Delete) operation should work properly.
+		"""
+
+		# Create
+		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
+		self.session.commit()
+		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
+		self.assertEqual(graph1.name, 'graph1')
+		self.session.add(GraphVersion(name='graphversion1', owner_email='owner@example.com', graph_id=graph1.id,
+		                             graph_json='{}', style_json='{}', description='{}'))
+		self.session.commit()
+		graphversion1 = self.session.query(GraphVersion).filter(Graph.owner_email == 'owner@example.com').one_or_none()
+		self.assertEqual(graphversion1.name, 'graphversion1')
+		#
+		# Update
+		graphversion1.name = 'updated_graph_version'
+		self.session.commit()
+		graphversion1 = self.session.query(GraphVersion).filter(Graph.owner_email == 'owner@example.com').one_or_none()
+		self.assertEqual(graphversion1.name, 'updated_graph_version')
+		#
+		# Delete
+		self.session.delete(graphversion1)
+		self.session.commit()
+		graphversion1 = self.session.query(GraphVersion).filter(Graph.owner_email == 'owner@example.com').one_or_none()
+		self.assertIsNone(graphversion1)
+
+		# Retrieve
+		num_graph_versions = self.session.query(GraphVersion).count()
+		self.assertEqual(num_graph_versions, 0)
+
+	def test_owner_email_fkey_constraint(self):
+
+		with self.assertRaises(IntegrityError):
+			self.session.add(GraphVersion(name='graphversion1', owner_email='owner@example.com', graph_id=0,
+		                             graph_json='{}', style_json='{}', description='{}'))
+			self.session.commit()
+
+	def test_graph_id_fkey_constraint(self):
+
+		with self.assertRaises(IntegrityError):
+			self.session.add(User(email='owner@example.com', password="password", is_admin=0))
+			self.session.add(GraphVersion(name='graphversion1', owner_email='owner@example.com', graph_id=0,
+		                             graph_json='{}', style_json='{}', description='{}'))
+			self.session.commit()
+
+	def test_cascade_on_user_delete(self):
+		"""
+		On deleting user row, the corresponding row in graph version table should also be deleted.
+		"""
+		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
+		self.session.commit()
+		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
+		self.session.add(GraphVersion(name='graphversion1', owner_email='owner@example.com', graph_id=graph1.id,
+									  graph_json='{}', style_json='{}', description='{}'))
+		self.session.commit()
+
+		owner = self.session.query(User).filter(User.email == 'owner@example.com').one_or_none()
+		self.session.delete(owner)
+		self.session.commit()
+		self.assertIsNone(self.session.query(User).filter(User.email == 'owner@example.com').one_or_none())
+
+		self.assertIsNone(self.session.query(GraphVersion).filter(and_(GraphVersion.owner_email == 'owner@example.com', GraphVersion.name == 'graphversion1')).one_or_none())
+		self.session.commit()
+
+	def test_cascade_on_user_update(self):
+		"""
+		On deleting user row, the corresponding row in graph version table should also be updated
+		"""
+		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
+		self.session.commit()
+		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
+		self.session.add(GraphVersion(name='graphversion1', owner_email='owner@example.com', graph_id=graph1.id,
+									  graph_json='{}', style_json='{}', description='{}'))
+		self.session.commit()
+		graphversion1 = self.session.query(GraphVersion).filter(and_(GraphVersion.owner_email == 'owner@example.com', GraphVersion.name == 'graphversion1')).one_or_none()
+
+		owner = self.session.query(User).filter(User.email == 'owner@example.com').one_or_none()
+		owner.email = 'owner_updated@example.com'
+		self.session.commit()
+
+		graphversion1 = self.session.query(GraphVersion).filter(GraphVersion.id == graphversion1.id).one_or_none()
+		self.assertEqual(graphversion1.owner_email, 'owner_updated@example.com')
+		self.session.commit()
+
+	def test_cascade_on_graph_delete(self):
+		"""
+		On deleting graph row, the corresponding row in graph version table should also be deleted.
+		"""
+		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
+		self.session.commit()
+		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
+		self.session.add(GraphVersion(name='graphversion1', owner_email='owner@example.com', graph_id=graph1.id,
+									  graph_json='{}', style_json='{}', description='{}'))
+		self.session.commit()
+
+		self.session.delete(graph1)
+		self.session.commit()
+		self.assertIsNone(self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none())
+
+		self.assertIsNone(self.session.query(GraphVersion).filter(and_(GraphVersion.owner_email == 'owner@example.com', GraphVersion.name == 'graphversion1')).one_or_none())
+		self.session.commit()
+
+	def test_cascade_on_graph_update(self):
+		"""
+		On deleting graph row, the corresponding row in graph version table should also be updated
+		"""
+		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
+		self.session.commit()
+		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
+		self.session.add(GraphVersion(name='graphversion1', owner_email='owner@example.com', graph_id=graph1.id,
+									  graph_json='{}', style_json='{}', description='{}'))
+		self.session.commit()
+		graphversion1 = self.session.query(GraphVersion).filter(and_(GraphVersion.owner_email == 'owner@example.com', GraphVersion.name == 'graphversion1')).one_or_none()
+
+		graph1.id = 10
+		self.session.commit()
+
+		graphversion1 = self.session.query(GraphVersion).filter(GraphVersion.id == graphversion1.id).one_or_none()
+		self.assertEqual(graphversion1.graph_id, graph1.id)
+		self.session.commit()
+
+	def test_graph_relationship(self):
+		self.session.add(User(email='owner@example.com', password="password", is_admin=0))
+		self.session.add(Graph(name='graph1', owner_email='owner@example.com', is_public=0))
+		self.session.commit()
+		graph1 = self.session.query(Graph).filter(Graph.owner_email == 'owner@example.com').one_or_none()
+		self.session.add(GraphVersion(name='graphversion1', owner_email='owner@example.com', graph_id=graph1.id,
+									  graph_json='{}', style_json='{}', description='{}'))
+		self.session.commit()
+
+		graph1 = self.session.query(Graph).filter(and_(Graph.owner_email == 'owner@example.com', Graph.name == 'graph1')).one_or_none()
+		graphversion1 = self.session.query(GraphVersion).filter(and_(GraphVersion.owner_email == 'owner@example.com', GraphVersion.name == 'graphversion1')).one_or_none()
+		self.assertEqual(graphversion1.graph.id, graph1.id)
 
 
 

--- a/applications/graphs/urls.py
+++ b/applications/graphs/urls.py
@@ -30,6 +30,8 @@ urlpatterns = [
 	# Graph Versions
 	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/version/$', views.graph_versions_ajax_api, name='graph_versions_ajax_api'),
 	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/version/(?P<version_id>[^/]+)$', views.graph_versions_ajax_api, name='graph_versions_ajax_api'),
+	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/version/(?P<version_id>[^/]+)/compatibility$', views.graph_versions_to_layout_ajax_api, name='graph_versions_to_layout_ajax_api'),
+	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/version/(?P<version_id>[^/]+)/compatibility/(?P<layout_id>[^/]+)$', views.graph_versions_to_layout_ajax_api, name='graph_versions_to_layout_ajax_api'),
 
 	# REST APIs Endpoints
 

--- a/applications/graphs/urls.py
+++ b/applications/graphs/urls.py
@@ -27,6 +27,9 @@ urlpatterns = [
 	# Graph Layouts
 	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/layouts/$', views.graph_layouts_ajax_api, name='graph_layouts_ajax_api'),
 	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/layouts/(?P<layout_id>[^/]+)$', views.graph_layouts_ajax_api, name='graph_layouts_ajax_api'),
+	# Graph Versions
+	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/version/$', views.graph_versions_ajax_api, name='graph_versions_ajax_api'),
+	url(r'^ajax/graphs/(?P<graph_id>[^/]+)/version/(?P<version_id>[^/]+)$', views.graph_versions_ajax_api, name='graph_versions_ajax_api'),
 
 	# REST APIs Endpoints
 
@@ -45,5 +48,8 @@ urlpatterns = [
 	# Graph Layouts
 	url(r'^api/v1/graphs/(?P<graph_id>[^/]+)/layouts/$', views.graph_layouts_rest_api, name='graph_layouts_rest_api'),
 	url(r'^api/v1/graphs/(?P<graph_id>[^/]+)/layouts/(?P<layout_id>[^/]+)$', views.graph_layouts_rest_api, name='graph_layouts_rest_api'),
+	# Graph Nodes
+	url(r'^api/v1/graphs/(?P<graph_id>[^/]+)/version/$', views.graph_versions_rest_api, name='graph_versions_rest_api'),
+	url(r'^api/v1/graphs/(?P<graph_id>[^/]+)/version/(?P<version_id>[^/]+)$', views.graph_versions_rest_api, name='graph_versions_rest_api'),
 
 ]

--- a/applications/graphs/views.py
+++ b/applications/graphs/views.py
@@ -114,6 +114,7 @@ def graph_page(request, graph_id):
 		else:
 			return redirect(request.get_full_path() + '?user_layout=' + context["default_layout_id"])
 
+	context['default_version_id'] = context['graph']['default_version_id']
 	context['graph_json_string'] = json.dumps(context['graph']['graph_json'])
 	context['data'] = {k: json.dumps(v, encoding='ascii') for k,v in context['graph']['graph_json']['data'].items()}
 	context['style_json_string'] = json.dumps(context['graph']['style_json'])

--- a/applications/graphs/views.py
+++ b/applications/graphs/views.py
@@ -1590,7 +1590,7 @@ def _graph_versions_api(request, graph_id, version_id=None):
 			return HttpResponse(json.dumps(_get_graph_version(request, graph_id, version_id)),
 			                    content_type="application/json")
 		elif request.method == "POST" and version_id is None:
-			return HttpResponse(json.dumps(_add_node(request, graph_id, node=json.loads(request.body))),
+			return HttpResponse(json.dumps(_add_graph_version(request, graph_id, graph_version=json.loads(request.body))),
 			                    content_type="application/json",
 			                    status=201)
 		elif request.method == "DELETE" and version_id is not None:
@@ -1684,3 +1684,44 @@ def _get_graph_version(request, graph_id, version_id):
 	"""
 	authorization.validate(request, permission='GRAPH_READ', graph_id=graph_id)
 	return utils.serializer(graphs.get_graph_version_by_id(request, version_id))
+
+@is_authenticated()
+def _add_graph_version(request, graph_id, graph_version={}):
+	"""
+	Node Parameters
+	----------
+	name : string
+		Name of the node. Required
+	owner_email : string
+		Email of the Owner of the graph. Required
+	graph_id : string
+		Unique ID of the graph. Required
+
+
+	Parameters
+	----------
+	graph_json : dict
+		Dictionary containing the graph_json data of the graph being added.
+	request : object
+		HTTP POST Request.
+
+	Returns
+	-------
+	graph_version : object
+		Newly created graph_version object.
+
+	Raises
+	------
+
+	Notes
+	------
+
+	"""
+	#
+
+	return utils.serializer(graphs.add_graph_version(request,
+	                                        name=graph_version.get('name', None),
+	                                        description=graph_version.get('description', None),
+	                                        owner_email=graph_version.get('owner_email', None),
+	                                        graph_json=graph_version.get('graph_json', None),
+	                                        graph_id=graph_id))

--- a/applications/graphs/views.py
+++ b/applications/graphs/views.py
@@ -1594,9 +1594,9 @@ def _graph_versions_api(request, graph_id, version_id=None):
 			                    content_type="application/json",
 			                    status=201)
 		elif request.method == "DELETE" and version_id is not None:
-			_delete_node(request, graph_id, version_id)
+			_delete_graph_version(request, graph_id, version_id)
 			return HttpResponse(json.dumps({
-				"message": "Successfully deleted node with id=%s" % (version_id)
+				"message": "Successfully deleted Graph Version with id=%s" % (version_id)
 			}), content_type="application/json", status=200)
 		else:
 			raise MethodNotAllowed(request)  # Handle other type of request methods like OPTIONS etc.
@@ -1725,3 +1725,29 @@ def _add_graph_version(request, graph_id, graph_version={}):
 	                                        owner_email=graph_version.get('owner_email', None),
 	                                        graph_json=graph_version.get('graph_json', None),
 	                                        graph_id=graph_id))
+
+@is_authenticated()
+def _delete_graph_version(request, graph_id, graph_version_id):
+	"""
+
+	Parameters
+	----------
+	request : object
+		HTTP GET Request.
+	graph_version_id : string
+		Unique ID of the Graph Version.
+
+	Returns
+	-------
+	None
+
+	Raises
+	------
+
+	Notes
+	------
+
+	"""
+	#authorization.validate(request, permission='GRAPH_UPDATE', graph_id=graph_id)
+
+	graphs.delete_graph_version_by_id(request, graph_version_id)

--- a/applications/graphs/views.py
+++ b/applications/graphs/views.py
@@ -1658,7 +1658,7 @@ def _get_graph_versions(request, graph_id, query={}):
 
 	return {
 		'total': total,
-		'versions': [utils.serializer(version) for version in versions_list]
+		'versions': [utils.serializer(version, summary=True) for version in versions_list]
 	}
 
 def _get_graph_version(request, graph_id, version_id):

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "animate.css": "^3.5.2",
     "cytoscape": "^2.7.11",
     "webcola": "^3.3.0",
-    "bower": "^3.3.7",
+    "bootstrap": "^3.3.7",
     "cytoscape-cola": "^1.6.0",
     "intro.js": "^2.4.0",
     "jquery-ui": "^1.12.1",

--- a/graphspace/database.py
+++ b/graphspace/database.py
@@ -20,6 +20,11 @@ class Database(object):
 		self.engine = create_engine(''.join(
 			['postgresql://', config['USER'], ':', config['PASSWORD'], '@', config['HOST'], ':', config['PORT'], '/', config['NAME']]), echo=False)
 		# TODO: Find out what is the use of metadata and reflection.
+		self.connection = self.engine.connect()
+		result = self.connection.execute("SELECT * FROM pg_extension where extname like 'pg_trgm'")
+		if result.rowcount==0:
+			self.connection.execute("create extension btree_gin")
+			self.connection.execute("create extension pg_trgm")
 		settings.BASE.metadata.create_all(self.engine)
 		self.meta = sqlalchemy.schema.MetaData()
 		self.meta.reflect(bind=self.engine)

--- a/migration/versions/09f74ae3229b_add_table_layout_compatibility.py
+++ b/migration/versions/09f74ae3229b_add_table_layout_compatibility.py
@@ -1,0 +1,37 @@
+"""add_table_layout_to_graph_version
+
+Revision ID: 09f74ae3229b
+Revises: bb9a45e2ee5e
+Create Date: 2018-06-24 17:30:43.566000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '09f74ae3229b'
+down_revision = 'bb9a45e2ee5e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+	op.create_table(
+		'layout_to_graph_version',
+		sa.Column('id', sa.Integer, primary_key=True),
+		sa.Column('layout_id', sa.String, nullable=False, unique=True),
+		sa.Column('graph_version_id', sa.Integer, nullable=False),
+		sa.Column('status', sa.String, nullable=True),
+	)
+	# Add date columns
+	op.add_column('layout_to_graph_version', sa.Column('created_at', sa.TIMESTAMP, server_default=sa.func.current_timestamp()))
+	op.add_column('layout_to_graph_version', sa.Column('updated_at', sa.TIMESTAMP, server_default=sa.func.current_timestamp()))
+
+	# Add Foreign Keys
+	op.execute('ALTER TABLE layout_to_graph_version ADD CONSTRAINT layout_to_graph_version_layout_id_fkey FOREIGN KEY (layout_id) REFERENCES "layout" (id) MATCH SIMPLE ON UPDATE CASCADE ON DELETE CASCADE;')
+	op.execute('ALTER TABLE layout_to_graph_version ADD CONSTRAINT layout_to_graph_version_graph_version_id_fkey FOREIGN KEY (graph_version_id) REFERENCES "graph_version" (id) MATCH SIMPLE ON UPDATE CASCADE ON DELETE CASCADE;')
+
+
+def downgrade():
+	op.drop_table('layout_to_graph_version')

--- a/migration/versions/840db85c5bce_update_graph_table_migrate_json_to_.py
+++ b/migration/versions/840db85c5bce_update_graph_table_migrate_json_to_.py
@@ -1,0 +1,41 @@
+"""update_graph_table_migrate_json_to_graph_version
+
+Revision ID: 840db85c5bce
+Revises: f8f6ba9712df
+Create Date: 2018-06-23 02:27:29.434000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '840db85c5bce'
+down_revision = 'f8f6ba9712df'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+	# Drop columns which have been migrated to graph_version table
+	op.drop_column('graph', 'style_json')
+	op.drop_column('graph', 'graph_json')
+
+	# Add new column for default_graph_version_id
+	op.add_column('graph', sa.Column('default_version_id', sa.Integer))
+
+	# Add new foreign key reference
+	op.execute('ALTER TABLE graph ADD CONSTRAINT graph_default_version_id_fkey FOREIGN KEY (default_version_id) REFERENCES "graph_version" (id) MATCH SIMPLE ON UPDATE CASCADE ON DELETE CASCADE;')
+
+def downgrade():
+
+	# Add columns which have been migrated to graph_version table
+	op.add_column('graph', sa.Column('style_json', sa.String))
+	op.add_column('graph', sa.Column('graph_json', sa.String))
+
+	# Remove foreign key reference
+	op.drop_constraint('graph_default_version_id_fkey', 'graph', type_='foreignkey')
+
+	# Drop column for default_graph_version_id
+	op.drop_column('graph', 'default_version_id')

--- a/migration/versions/f8f6ba9712df_create_graph_versions_table.py
+++ b/migration/versions/f8f6ba9712df_create_graph_versions_table.py
@@ -1,0 +1,42 @@
+"""create_graph_versions_table
+
+Revision ID: f8f6ba9712df
+Revises: bb9a45e2ee5e
+Create Date: 2018-06-22 23:08:39.459000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f8f6ba9712df'
+down_revision = 'bb9a45e2ee5e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+	op.create_table(
+		'graph_version',
+		sa.Column('id', sa.Integer, primary_key=True),
+		sa.Column('name', sa.String, nullable=False, unique=True),
+		sa.Column('graph_id', sa.Integer, nullable=False),
+		sa.Column('owner_email', sa.String, nullable=False),
+		sa.Column('graph_json', sa.String, nullable=False),
+		sa.Column('style_json', sa.String, nullable=False),
+		sa.Column('description', sa.String, nullable=False),
+	)
+	op.add_column('graph_version', sa.Column('created_at', sa.TIMESTAMP, server_default=sa.func.current_timestamp()))
+	op.add_column('graph_version', sa.Column('updated_at', sa.TIMESTAMP, server_default=sa.func.current_timestamp()))
+	# Create New Index
+	op.create_index('graph_version_idx_name', 'graph_version', ['name'], unique=True)
+	# Add new foreign key reference
+	op.execute('ALTER TABLE graph_version ADD CONSTRAINT graph_version_graph_id_fkey FOREIGN KEY (graph_id) REFERENCES "graph" (id) MATCH SIMPLE ON UPDATE CASCADE ON DELETE CASCADE;')
+	op.execute('ALTER TABLE graph_version ADD CONSTRAINT graph_version_owner_email_fkey FOREIGN KEY (owner_email) REFERENCES "user" (email) MATCH SIMPLE ON UPDATE CASCADE ON DELETE CASCADE;')
+
+
+
+
+def downgrade():
+	op.drop_table('graph_version')

--- a/static/css/graphspace.css
+++ b/static/css/graphspace.css
@@ -439,3 +439,12 @@ p.lead {
         margin-left: 0;
     }
 }
+.graph_version_span {
+    cursor:pointer;
+    color:#337ab7;
+
+}
+
+.graph_version_span:hover {
+    text-decoration:underline;
+}

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -44,6 +44,9 @@ var apis = {
         get: function (graph_id, data, successCallback, errorCallback) {
             apis.jsonRequest('GET', apis.version.ENDPOINT({'graph_id': graph_id}), data, successCallback, errorCallback)
         },
+        getByID: function (graph_id, version_id, successCallback, errorCallback) {
+            apis.jsonRequest('GET', apis.version.ENDPOINT({'graph_id': graph_id}) + version_id, undefined, successCallback, errorCallback)
+        },
     },
     edges: {
         ENDPOINT: _.template('/ajax/graphs/<%= graph_id %>/edges/'),
@@ -524,6 +527,22 @@ var graphPage = {
     },
     export: function (format) {
         cytoscapeGraph.export(graphPage.cyGraph, format, $('#GraphName').val());
+    },
+    selectGraphVersion: function (row) {
+        label = $("#version_selector_dropdown").find('a[row_id=' + row + ']').attr('data')
+
+        apis.version.getByID($('#GraphID').val(), row,
+            successCallback = function (response) {
+                graph_json = JSON.parse(response.graph_json);
+                graphPage.contructCytoscapeGraph();
+                console.log("Success");
+            },
+            errorCallback = function (xhr, status, errorThrown) {
+                // This method is called when  error occurs while deleting group_to_graph relationship.
+                $.notify({message: "You are not authorized to access this Version."}, {type: 'danger'});
+            });
+        $('#version_selector > bold').text(label);
+        console.log("abc");
     },
     applyAutoLayout: function (layout_id) {
         graphPage.applyLayout(cytoscapeGraph.getAutomaticLayoutSettings(layout_id));
@@ -1163,7 +1182,11 @@ var graphPage = {
                     params.error('Error');
                 }
             );
-        }
+        },
+        versionFormatter: function (value, row, index) {
+            $("#version_selector_dropdown").append('<li><a row_id="'+row.id+'" data="' + value +'" onclick="graphPage.selectGraphVersion(' + row.id + ');">' + value + '</a></li>')
+            return ('<span class="graph_version_span"  >'+ value +'</span>')
+    }
     },
     layoutsTable: {
         getPrivateLayoutsByGraphID: function (params) {

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -39,6 +39,12 @@ var apis = {
             apis.jsonRequest('GET', apis.nodes.ENDPOINT({'graph_id': graph_id}), data, successCallback, errorCallback)
         },
     },
+    version: {
+        ENDPOINT: _.template('/ajax/graphs/<%= graph_id %>/version/'),
+        get: function (graph_id, data, successCallback, errorCallback) {
+            apis.jsonRequest('GET', apis.version.ENDPOINT({'graph_id': graph_id}), data, successCallback, errorCallback)
+        },
+    },
     edges: {
         ENDPOINT: _.template('/ajax/graphs/<%= graph_id %>/edges/'),
         get: function (graph_id, data, successCallback, errorCallback) {
@@ -1116,6 +1122,38 @@ var graphPage = {
             params.data["graph_id"] = $('#GraphID').val();
 
             apis.nodes.get($('#GraphID').val(), params.data,
+                successCallback = function (response) {
+                    // This method is called when nodes are successfully fetched.
+                    params.success(response);
+                },
+                errorCallback = function () {
+                    // This method is called when error occurs while fetching nodes.
+                    params.error('Error');
+                }
+            );
+        }
+    },
+    graphVersionTable: {
+        getVersionByGraphID: function (params) {
+            /**
+             * This is the custom ajax request used to load version in graphVersionTable.
+             *
+             * params - query parameters for the ajax request.
+             *          It contains parameters like limit, offset, search, sort, order.
+             */
+
+            if (params.data["search"]) {
+                params.data["names"] = _.map(_.filter(_.split(params.data["search"], ','), function (s) {
+                    return s.indexOf(':') === -1;
+                }), function (str) {
+                    return '%' + str + '%';
+                });
+                params.data["labels"] = params.data["names"];
+            }
+
+            params.data["graph_id"] = $('#GraphID').val();
+
+            apis.version.get($('#GraphID').val(), params.data,
                 successCallback = function (response) {
                     // This method is called when nodes are successfully fetched.
                     params.success(response);

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -529,20 +529,23 @@ var graphPage = {
         cytoscapeGraph.export(graphPage.cyGraph, format, $('#GraphName').val());
     },
     selectGraphVersion: function (row) {
-        label = $("#version_selector_dropdown").find('a[row_id=' + row + ']').attr('data')
+        label = $("#version_selector_dropdown").find('a[row_id=' + row + ']').attr('data');
+        $("#GraphVersionTable").find('tr').removeClass('success');
 
         apis.version.getByID($('#GraphID').val(), row,
             successCallback = function (response) {
                 graph_json = JSON.parse(response.graph_json);
-                graphPage.contructCytoscapeGraph();
-                console.log("Success");
+                //graphPage.contructCytoscapeGraph();
+                graphPage.init();
+                $("#version_selector_dropdown").attr('current_version_id', row);
+                $("#GraphVersionTable").find('span[row_id=' + row + ']').parent().parent().addClass('success');
+                //console.log("Success");
             },
             errorCallback = function (xhr, status, errorThrown) {
                 // This method is called when  error occurs while deleting group_to_graph relationship.
                 $.notify({message: "You are not authorized to access this Version."}, {type: 'danger'});
             });
         $('#version_selector > bold').text(label);
-        console.log("abc");
     },
     applyAutoLayout: function (layout_id) {
         graphPage.applyLayout(cytoscapeGraph.getAutomaticLayoutSettings(layout_id));
@@ -714,7 +717,9 @@ var graphPage = {
     onShareGraphWithPublicBtn: function (e, graph_id) {
 
         apis.graphs.update(graph_id, {
-                'is_public': 1
+                'is_public': 1,
+                'version_id': parseInt( $("#version_selector_dropdown").attr('current_version_id')),
+                'style_json': style_json //JSON.stringify(style_json)
             },
             successCallback = function (response) {
                 // This method is called when group_to_graph relationship is successfully deleted.
@@ -1176,6 +1181,9 @@ var graphPage = {
                 successCallback = function (response) {
                     // This method is called when nodes are successfully fetched.
                     params.success(response);
+                    default_version = response.versions.find(x => x.id === default_version_id);
+                    default_version ? $('#current_version_label').text(default_version.name) : $('#current_version_label').text('Default');
+                    $("#GraphVersionTable").find('span[row_id=' + default_version_id + ']').parent().parent().addClass('success');
                 },
                 errorCallback = function () {
                     // This method is called when error occurs while fetching nodes.
@@ -1185,7 +1193,7 @@ var graphPage = {
         },
         versionFormatter: function (value, row, index) {
             $("#version_selector_dropdown").append('<li><a row_id="'+row.id+'" data="' + value +'" onclick="graphPage.selectGraphVersion(' + row.id + ');">' + value + '</a></li>')
-            return ('<span class="graph_version_span"  >'+ value +'</span>')
+            return ('<span class="graph_version_span" onclick="graphPage.selectGraphVersion(' + row.id + ');" row_id="'+row.id+'">'+ value +'</span>')
     }
     },
     layoutsTable: {

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -536,6 +536,8 @@ var graphPage = {
             successCallback = function (response) {
                 graph_json = JSON.parse(response.graph_json);
                 //graphPage.contructCytoscapeGraph();
+                $("#graphVisualizationTabBtn.link-reset").click();
+                $(location).attr('href', '#graph_visualization_tab');
                 graphPage.init();
                 $("#version_selector_dropdown").attr('current_version_id', row);
                 $("#GraphVersionTable").find('span[row_id=' + row + ']').parent().parent().addClass('success');
@@ -1176,7 +1178,7 @@ var graphPage = {
             }
 
             params.data["graph_id"] = $('#GraphID').val();
-
+            params.data["owner_email"] = $('#UserEmail').val();
             apis.version.get($('#GraphID').val(), params.data,
                 successCallback = function (response) {
                     // This method is called when nodes are successfully fetched.

--- a/templates/graph/graph_version_table.html
+++ b/templates/graph/graph_version_table.html
@@ -1,0 +1,36 @@
+
+<div class="margin-top-4">
+    <b>Currently Viewing :</b>
+    <br>
+    <b>Default Version :</b>
+</div>
+
+<table id="GraphVersionTable"
+       data-toggle="table"
+       data-show-refresh="true"
+       data-show-columns="false"
+       data-show-toggle="true"
+       data-ajax="graphPage.graphVersionTable.getVersionByGraphID"
+       data-search="true"
+       data-side-pagination="server"
+       data-data-field="nodes"
+       data-pagination="true"
+       data-sort-name="name"
+       data-id-field="id"
+       data-sort-order="asc">
+    <thead>
+    <tr>
+        <th data-field="name" data-sortable="True">Version Name</th>
+        <th data-field="label">Description</th>
+        {#        <th data-field="updated_at" data-formatter="utils.dateFormatter" data-sortable="True">Last#}
+        {#            Modified#}
+        {#        </th>#}
+        <th data-field="label">Created on</th>
+        {% if uid %}
+            <th data-field="operations" data-visible="false">
+                Operations
+            </th>
+        {% endif %}
+    </tr>
+    </thead>
+</table>

--- a/templates/graph/graph_version_table.html
+++ b/templates/graph/graph_version_table.html
@@ -1,7 +1,5 @@
 
 <div class="margin-top-4">
-    <b>Currently Viewing :</b>
-    <br>
     <b>Default Version :</b>
 </div>
 

--- a/templates/graph/graph_version_table.html
+++ b/templates/graph/graph_version_table.html
@@ -1,8 +1,3 @@
-
-<div class="margin-top-4">
-    <b>Default Version :</b>
-</div>
-
 <table id="GraphVersionTable"
        data-toggle="table"
        data-show-refresh="true"

--- a/templates/graph/graph_version_table.html
+++ b/templates/graph/graph_version_table.html
@@ -13,19 +13,19 @@
        data-ajax="graphPage.graphVersionTable.getVersionByGraphID"
        data-search="true"
        data-side-pagination="server"
-       data-data-field="nodes"
+       data-data-field="versions"
        data-pagination="true"
        data-sort-name="name"
        data-id-field="id"
        data-sort-order="asc">
     <thead>
     <tr>
-        <th data-field="name" data-sortable="True">Version Name</th>
-        <th data-field="label">Description</th>
+        <th data-field="name" data-formatter="graphPage.graphVersionTable.versionFormatter" data-sortable="True">Version Name</th>
+        <th data-field="description">Description</th>
         {#        <th data-field="updated_at" data-formatter="utils.dateFormatter" data-sortable="True">Last#}
         {#            Modified#}
         {#        </th>#}
-        <th data-field="label">Created on</th>
+        <th data-field="created_at">Created on</th>
         {% if uid %}
             <th data-field="operations" data-visible="false">
                 Operations

--- a/templates/graph/index.html
+++ b/templates/graph/index.html
@@ -225,6 +225,14 @@
                     <a class="link-reset" href="#graph_version_tab" data-toggle="tab">Graph Version</a>
                 </li>
             {% endif %}
+            <div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 20000">
+                    <button type="button" id="version_selector" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown"
+                            aria-haspopup="true" aria-expanded="false">
+                        <i> Branch :</i> <bold style="font-weight: bold" >Version</bold> <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" id="version_selector_dropdown">
+                    </ul>
+                </div>
         </ul>
 
         <div id="myTabContent" class="tab-content gs-full-height bg-white">

--- a/templates/graph/index.html
+++ b/templates/graph/index.html
@@ -220,6 +220,11 @@
                     <a class="link-reset" href="#graph_layouts_tab" data-toggle="tab">Layouts</a>
                 </li>
             {% endif %}
+            {% if uid %}
+                <li class="text-center">
+                    <a class="link-reset" href="#graph_version_tab" data-toggle="tab">Graph Version</a>
+                </li>
+            {% endif %}
         </ul>
 
         <div id="myTabContent" class="tab-content gs-full-height bg-white">
@@ -273,6 +278,9 @@
 
             <div class="tab-pane fade gs-full-height" id="graph_layouts_tab">
                 {% include 'graph/layouts_table.html' %}
+            </div>
+            <div class="tab-pane fade gs-full-height container" id="graph_version_tab">
+                {% include 'graph/graph_version_table.html' %}
             </div>
 
         </div>

--- a/templates/graph/index.html
+++ b/templates/graph/index.html
@@ -6,6 +6,7 @@
             var graph_json = {{ graph_json_string|safe }};
             var style_json = {{ style_json_string|safe }};
             var default_layout_id = {% if default_layout_id %}{{ default_layout_id|safe }}{% else %}null{% endif %};
+            var default_version_id = {% if default_version_id %}{{ default_version_id|safe }}{% else %}null{% endif %};
         {% endif %}
     </script>
 
@@ -228,9 +229,9 @@
             <div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 20000">
                     <button type="button" id="version_selector" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown"
                             aria-haspopup="true" aria-expanded="false">
-                        <i> Branch :</i> <bold style="font-weight: bold" >Version</bold> <span class="caret"></span>
+                        <i> Version :</i> <bold style="font-weight: bold" id="current_version_label">--------</bold> <span class="caret"></span>
                     </button>
-                    <ul class="dropdown-menu" id="version_selector_dropdown">
+                    <ul class="dropdown-menu" id="version_selector_dropdown" current_version_id="">
                     </ul>
                 </div>
         </ul>

--- a/templates/graph/index.html
+++ b/templates/graph/index.html
@@ -226,6 +226,11 @@
                     <a class="link-reset" href="#graph_version_tab" data-toggle="tab">Graph Version</a>
                 </li>
             {% endif %}
+            {% if uid %}
+                <li id="layout_compatibility_navtab" class="text-center bg-danger invisible">
+                    <a class="link-reset" href="#layout_compatibility_tab" data-toggle="tab">Layout Compatibility</a>
+                </li>
+            {% endif %}
             <div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 20000">
                     <button type="button" id="version_selector" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown"
                             aria-haspopup="true" aria-expanded="false">
@@ -291,7 +296,9 @@
             <div class="tab-pane fade gs-full-height container" id="graph_version_tab">
                 {% include 'graph/graph_version_table.html' %}
             </div>
-
+            <div class="tab-pane fade gs-full-height container" id="layout_compatibility_tab">
+                {% include 'graph/layout_compatibility_table.html' %}
+            </div>
         </div>
 
     </div>

--- a/templates/graph/layout_compatibility_modal.html
+++ b/templates/graph/layout_compatibility_modal.html
@@ -1,0 +1,61 @@
+<div class="modal fade" id="applyLayoutModal" tabindex="-1" role="dialog" aria-labelledby="checkLayoutCompatibilityModal"
+     aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="applyLModal">Apply Selected Layout</h4>
+            </div>
+            <div class="modal-body">
+
+                <h4>The selected layout is compatible with the current version of this Graph.</h4>
+                <h4>Are you sure you want to apply this layout?</h4>
+                <br/>
+                <button type="button" id="ConfirmApplyLayoutBtn" class="btn btn-success">
+                    Apply Layout
+                </button>
+                <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
+
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="checkLayoutCompatibilityModal" tabindex="-1" role="dialog" aria-labelledby="checkLayoutCompatibilityModal"
+     aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="checkLayoutModal">Check Layout Compatibility</h4>
+            </div>
+            <div class="modal-body">
+
+                <h4>The compatibility of this Layout is unknown for the selected version of the Graph</h4>
+                <h4>Do you want to run Compatibility check?</h4>
+                <br/>
+                <button type="button" id="ConfirmRemoveLayoutBtn" class="btn btn-success">
+                    Check Layout Compatibility
+                </button>
+                <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
+
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="nonCompatibleLayoutModal" tabindex="-1" role="dialog" aria-labelledby="checkLayoutCompatibilityModal"
+     aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="nonLayoutModal">Layout not compatible</h4>
+            </div>
+            <div class="modal-body">
+
+                <h4>This layout is not compatible with the current version of the Graph</h4>
+                <br/>
+                <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/graph/layout_compatibility_table.html
+++ b/templates/graph/layout_compatibility_table.html
@@ -1,0 +1,21 @@
+<table id="LayoutCompatibilityTable"
+       data-toggle="table"
+       data-show-refresh="true"
+       data-show-columns="false"
+       data-show-toggle="true"
+       data-ajax="graphPage.layoutCompatibilityTable.getConflictingLayoutElements"
+       data-search="true"
+       data-side-pagination="data"
+       data-data-field="data"
+       data-pagination="true"
+       data-sort-name="name"
+       data-id-field="id"
+       data-sort-order="asc">
+    <thead>
+    <tr>
+        <th data-field="name"  data-formatter="graphPage.layoutCompatibilityTable.elementsFormatter" data-sortable="True">Element Name</th>
+        <th data-field="name"  data-formatter="graphPage.layoutCompatibilityTable.selectorFormatter" data-sortable="True">Selector</th>
+        <!-- <th data-field="style" data-formatter="graphPage.layoutCompatibilityTable.styleFormatter">Style</th> -->
+    </tr>
+    </thead>
+</table>


### PR DESCRIPTION
## Purpose
This patch implements Layout Compatibility Check- Allow users to check whether a layout is compatible with a particular Graph Version.

### Feature Details
GraphSpace allows its users to create custom layouts and with the addition of Version Control feature there could be scenarios where a particular user created layout may or may not be compatible with a given version of the Graph. This patch will allow users to check whether a layout is compatible or not. 

The following features are available in the Layout Compatibility functionality:

- [Checking Layout Compatibility](#checking_layout-compatibility)
- [Layout Compatibility Tab](#layout-compatibility-tab)


## Checking Layout Compatibility

Anytime a User tries to apply a Layout on a particular version of the Graph, GraphSpace checks the layout compatibility status and does one of the following operations :
1. If the compatibility status is `True`, then it the Layout is applied on the current version of the Graph.
2. If the compatibility statis is `False`, then the user is notified that the selected layout is incompatible and cannot be applied for the current version of the Graph.
3. If compatibility is `undefined` or `unknown`, then a check is performed to determine whether the layout is compatible with the current version of the graph or not.

### Incompatible Nodes and Edges

GraphSpace Users will be notified about the Nodes & Edges which are incompatible for the current selection of Layout and Graph Version.

![gs-screenshot-localuser1- layout-compatibility-notify](https://user-images.githubusercontent.com/4581090/42420311-0f856a34-82c4-11e8-93ef-9821ffb876bf.PNG)


## Layout Compatibility Tab

The `Layout Compatibility` tab displays a list of incompatible nodes & edges for the current layout and graph version. The tab is visible only when there are compatibility issues for the selected layout with the current version of the graph. The incompatible elements are displayed in a table format. The table contains following columns:

1. **Element Name** - Name of the incompatible Node or Edge.
2. **Selector** - The selector for this particular element.

The table allows sorting based on Element Name. In order to sort by element type (node or edge) the user can click on Selector header in the table.
The image below shows an example of Layout Compatibility Tab when a user clicks on the `Layout Compatibility` tab link:

![layout_comp_tab](https://user-images.githubusercontent.com/4581090/42420316-2b3573b4-82c4-11e8-9ff5-154b90ede6e6.gif)



### Edit Nodes & Edges

Users of GraphSpace can edit the layout of incompatible nodes and edges by clicking on the `selector` in the Layout Compatibility table.

![layout_comp_edit](https://user-images.githubusercontent.com/4581090/42420318-399d71ea-82c4-11e8-8eb9-ee448ea8b250.gif)


#### Open Questions and Pre-Merge TODOs
@jahandaniyal 
- [x] PR documentation 
    - [x] Document API changes
    - [x] Document UI changes (mainly GIFs and screenshots)
- [x] User documentation
- [x] API documentation in RAML
    - [x] Add a screenshot of HTML docs generated from RAML here. 
- [ ] Developer documentation in Wiki
- [x] Python documentation in Code
- [x] Write tests in Python

## Learning
[http://gsoc18.blogspot.com/](http://gsoc18.blogspot.com/)
_Links to blog posts, patterns, libraries or addons used to solve this problem_

#### Blog Posts
- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.