### PR TITLE
Fix issue 400 -- Error: e.cyTarget is undefined for upgraded Cytoscape.js version 3.2.17

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Invoke GNU Mailman3 REST API.
 
 #### Open Questions and Pre-Merge TODOs
 - [ ] Merge [validates email address by sending a confirmation email to users](https://github.com/Murali-group/GraphSpace/pull/368)
-- [ ] [Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Install-and-Configure-Mailman3-Suite-for-GraphSpace-(Ubuntu-16.04,-PostgreSQL,-Apache2,-Postfix)
+- [ ] [Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Running-GraphSpace-Locally)
 - [ ] Create the email lists of GraphSpace and add them to settings file
 - [ ] Update the database.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,19 @@
 ## Purpose
-_Describe the problem or feature in addition to a link to the issues._
-
-Example:
-Fixes # .
+Built announcements and users email lists to post important announcements and allow users to communicate with each other. 
 
 ## Approach
-_How does this change address the problem?_
+Invoke GNU Mailman3 REST API. 
 
 #### Open Questions and Pre-Merge TODOs
-- [ ] Use github checklists. When solved, check the box and explain the answer.
+- [ ] Merge [validates email address by sending a confirmation email to users](https://github.com/Murali-group/GraphSpace/pull/368)
+- [ ] [Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Install-and-Configure-Mailman3-Suite-for-GraphSpace-(Ubuntu-16.04,-PostgreSQL,-Apache2,-Postfix)
+- [ ] Create the email lists of GraphSpace and add them to settings file
+- [ ] Update the database.
 
 ## Learning
-_Describe the research stage_
+[Mailman 3 suite documents](http://docs.mailman3.org/en/latest/)
+[Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Install-and-Configure-Mailman3-Suite-for-GraphSpace-(Ubuntu-16.04,-PostgreSQL,-Apache2,-Postfix)
 
-_Links to blog posts, patterns, libraries or addons used to solve this problem_
 
 #### Blog Posts
 - [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,19 @@
 ## Purpose
-Built announcements and users email lists to post important announcements and allow users to communicate with each other. 
+_Describe the problem or feature in addition to a link to the issues._
+
+Example:
+Fixes # .
 
 ## Approach
-Invoke GNU Mailman3 REST API. 
+_How does this change address the problem?_
 
 #### Open Questions and Pre-Merge TODOs
-- [ ] Merge [validates email address by sending a confirmation email to users](https://github.com/Murali-group/GraphSpace/pull/368)
-- [ ] [Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Install-and-Configure-Mailman3-Suite-for-GraphSpace-(Ubuntu-16.04,-PostgreSQL,-Apache2,-Postfix))
-- [ ] Create the email lists of GraphSpace and add them to settings file
-- [ ] Update the database.
+- [ ] Use github checklists. When solved, check the box and explain the answer.
 
 ## Learning
-[Mailman 3 suite documents](http://docs.mailman3.org/en/latest/)
+_Describe the research stage_
 
-[Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Install-and-Configure-Mailman3-Suite-for-GraphSpace-(Ubuntu-16.04,-PostgreSQL,-Apache2,-Postfix))
-
+_Links to blog posts, patterns, libraries or addons used to solve this problem_
 
 #### Blog Posts
 - [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,14 +6,14 @@ Invoke GNU Mailman3 REST API.
 
 #### Open Questions and Pre-Merge TODOs
 - [ ] Merge [validates email address by sending a confirmation email to users](https://github.com/Murali-group/GraphSpace/pull/368)
-- [ ] [Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Running-GraphSpace-Locally)
+- [ ] [Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Install-and-Configure-Mailman3-Suite-for-GraphSpace-(Ubuntu-16.04,-PostgreSQL,-Apache2,-Postfix))
 - [ ] Create the email lists of GraphSpace and add them to settings file
 - [ ] Update the database.
 
 ## Learning
 [Mailman 3 suite documents](http://docs.mailman3.org/en/latest/)
 
-[Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Install-and-Configure-Mailman3-Suite-for-GraphSpace-(Ubuntu-16.04,-PostgreSQL,-Apache2,-Postfix)
+[Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Install-and-Configure-Mailman3-Suite-for-GraphSpace-(Ubuntu-16.04,-PostgreSQL,-Apache2,-Postfix))
 
 
 #### Blog Posts

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@ Invoke GNU Mailman3 REST API.
 
 ## Learning
 [Mailman 3 suite documents](http://docs.mailman3.org/en/latest/)
+
 [Install and Configure Mailman3 Suite for GraphSpace](https://github.com/Murali-group/GraphSpace/wiki/Install-and-Configure-Mailman3-Suite-for-GraphSpace-(Ubuntu-16.04,-PostgreSQL,-Apache2,-Postfix)
 
 

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -870,7 +870,7 @@ var graphPage = {
     },
     onTapGraphElement: function (evt) {
         // get target
-        var target = evt.cyTarget;
+        var target = evt.Target;
         // target some element other than background (node/edge)
         if (target !== this) {
             var popup = target._private.data.popup;
@@ -1386,7 +1386,7 @@ var graphPage = {
 
             graphPage.cyGraph.on('free', function (e) {
 
-                var selected_elements = e.cyTarget.length > 1 ? graphPage.cyGraph.elements(':selected') : e.cyTarget;
+                var selected_elements = e.Target.length > 1 ? graphPage.cyGraph.elements(':selected') : e.Target;
                 graphPage.layoutEditor.undoRedoManager.update({
                     'action_type': 'move_node',
                     'data': {
@@ -2443,7 +2443,7 @@ var cytoscapeGraph = {
                         title: 'edit selected nodes',
                         selector: 'node',
                         onClickFunction: function (event) {
-                            graphPage.layoutEditor.nodeEditor.open(cy.collection(cy.elements(':selected')).add(event.cyTarget).select());
+                            graphPage.layoutEditor.nodeEditor.open(cy.collection(cy.elements(':selected')).add(event.Target).select());
                         },
                         hasTrailingDivider: true
                     },
@@ -2453,7 +2453,7 @@ var cytoscapeGraph = {
                         selector: 'node',
                         show: true,
                         onClickFunction: function (event) {
-                            selectAllOfTheSameType(event.cyTarget);
+                            selectAllOfTheSameType(event.Target);
                         }
                     },
                     {
@@ -2462,7 +2462,7 @@ var cytoscapeGraph = {
                         selector: 'node',
                         show: true,
                         onClickFunction: function (event) {
-                            unselectAllOfTheSameType(event.cyTarget);
+                            unselectAllOfTheSameType(event.Target);
                         }
                     },
                     {
@@ -2471,7 +2471,7 @@ var cytoscapeGraph = {
                         selector: 'edge',
                         show: true,
                         onClickFunction: function (event) {
-                            selectAllOfTheSameType(event.cyTarget);
+                            selectAllOfTheSameType(event.Target);
                         }
                     },
                     {
@@ -2480,7 +2480,7 @@ var cytoscapeGraph = {
                         selector: 'edge',
                         show: true,
                         onClickFunction: function (event) {
-                            unselectAllOfTheSameType(event.cyTarget);
+                            unselectAllOfTheSameType(event.Target);
                         }
                     }
                 ]


### PR DESCRIPTION

Fixes #400

Cytoscape.js V3 has removed 'cy' prefix on event fields. Refer: https://github.com/cytoscape/cytoscape.js/issues/1537

This pull request changed all `cyTarget` to `Target` in graphs_page.js.


