### PR TITLE
Added a Save Layout button on the Layouts pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ WSGIScriptAlias / /path_to_GraphSpace/graphspace/wsgi.py
      </Files>
   </Directory>
   
-  Alias /static/ /path_to_GraphSpace/graphs/static/
+  Alias /static/ /path_to_GraphSpace/static/
   
-  <Directory /path_to_GraphSpace/graphs/static/>
+  <Directory /path_to_GraphSpace/static/>
       Require all granted
   </Directory>
   

--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -452,9 +452,6 @@ var graphPage = {
         });
 
         $('#saveLayoutBtn').click(function () {
-
-            cytoscapeGraph.showGraphInformation(graphPage.cyGraph);
-
             graphPage.saveLayout($('#saveLayoutNameInput').val(), '#saveLayoutModal');
         });
 

--- a/templates/graph/default_sidebar.html
+++ b/templates/graph/default_sidebar.html
@@ -34,7 +34,13 @@
             Change Layout
         </a>
     </li>
+
     {% if uid %}
+        <li>
+            <a id="saveLayoutEditorBtn" class="btn sidebar-nav-pills" href="#" data-target="#defaultSideBar">
+                Save Layout
+            </a>
+        </li>
         <li>
             <a id="layoutEditorBtn" class="btn sidebar-nav-pills" href="#editor" data-target="#layoutEditorSideBar">
                 <i class="fa fa-pencil-square-o fa-lg"></i> Use Layout <br> Editor

--- a/templates/graph/index.html
+++ b/templates/graph/index.html
@@ -116,7 +116,8 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h4 class="modal-title" id="myModalLabel">Save Layout</h4>
+                        <h4 class="modal-title" id="myModalLabel">Save Positions and Style</h4>
+                        <h6 class="modal-title" id="myModalLabel">Save the current x- and y-coordinates of every node and the style attributes of every node and edge</h6>
                     </div>
                     <div class="modal-body">
 
@@ -129,7 +130,7 @@
                             <br>
                             <div class="form-group">
                                 <button name="saveLayoutBtn" id="saveLayoutBtn"
-                                        class="btn btn-success sidebar-nav-pills" data-target="#layoutEditorSideBar">Save
+                                        class="btn btn-success sidebar-nav-pills" data-target="#defaultSideBar">Save
                                 </button>
                                 <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
                             </div>


### PR DESCRIPTION
## Purpose
Adding a "Save Layout" button on the Layouts pane

Fixes https://github.com/Murali-group/GraphSpace/issues/392

In the gif below, I have tried to demonstrate the above solution
![best](https://user-images.githubusercontent.com/18470647/50969071-2ae13c00-1503-11e9-8960-f9ff2bbbf020.gif)


## Approach
On pressing the "Save Layout" button, a dialogue box asking to save the layout pops up and the user can now directly save the layout generated without entering the Layout Editor and immediately exiting out. 

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.


