### PR TITLE
Fixed - Modified Timestamp Does Not Reflect Recent Actions

### DIFF
--- a/graphspace/mixins.py
+++ b/graphspace/mixins.py
@@ -17,4 +17,4 @@ class IDMixin(object):
 
 class TimeStampMixin(object):
 	created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
-	updated_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+	updated_at = Column(TIMESTAMP, server_default=func.now(), nullable=False, onupdate=func.now())


### PR DESCRIPTION
## Purpose
Fixes - #383 
This patch fixes the `updated_at` timestamp which was not reflecting correct time when **GraphSpace** entities like Graph/Layout were modified.


Example:
To test curl or send the following request in postman - 
URL : http://127.0.0.1:8000/api/v1/graphs/{graph_id}
BODY : 
`{
     "name" : "Test_updated_at"
}`
## Approach
In the graphspace/mixins.py there is a **TimeStampMixin** Class which was lacking `onupdate` attribute for **updated_at** field. 
Adding the attribute `onupdate=func.now()` fixes this issue.  
All update/put queries on any GraphSpace element will reflect the correct timestamp.

![b 383](https://user-images.githubusercontent.com/4581090/51605736-2c9dfd00-1f10-11e9-92db-55e189a13066.gif)

#### Open Questions and Pre-Merge TODOs
- [x] Use github checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

#### Blog Posts
- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.


