### PR TITLE
How to Cite Graphspace in about us page: fixes #431

### DIFF
--- a/templates/about_us/index.html
+++ b/templates/about_us/index.html
@@ -41,6 +41,11 @@
 
         </ul>
 
+        <h3 style="padding-top: 50px; margin-top: -40px;" id="lib">How to Cite GraphSpace</h3>
+            <a href="https://academic.oup.com/bioinformatics/article/33/19/3134/3867143">GraphSpace: Stimulating Interdisciplinary Collaborations in Network Biology, </a>
+            Aditya Bharadwaj, Divit P. Singh, Anna Ritz, Allison N. Tegge, Christopher L. Poirel, Pavel Kraikivski, Neil Adames, Kurt Luther, Shiv D. Kale, Jean Peccoud, John J. Tyson, and T. M. Murali, Bioinformatics, 13 (19), 3134-3136, 2017
+
+
     </div>
 
 {% endblock %}

--- a/templates/about_us/index.html
+++ b/templates/about_us/index.html
@@ -42,6 +42,7 @@
         </ul>
 
         <h3 style="padding-top: 50px; margin-top: -40px;" id="lib">How to Cite GraphSpace</h3>
+            If you use GraphSpace in your research, please cite the following paper:<br/>
             <a href="https://academic.oup.com/bioinformatics/article/33/19/3134/3867143">GraphSpace: Stimulating Interdisciplinary Collaborations in Network Biology, </a>
             Aditya Bharadwaj, Divit P. Singh, Anna Ritz, Allison N. Tegge, Christopher L. Poirel, Pavel Kraikivski, Neil Adames, Kurt Luther, Shiv D. Kale, Jean Peccoud, John J. Tyson, and T. M. Murali, Bioinformatics, 13 (19), 3134-3136, 2017
 


### PR DESCRIPTION
## Purpose
How to cite Graphspace with a citation example is put into the About us Page

Example:
Fixes #431  .

## Approach
Changed aboutUs/index.html

## Learning

![HowToCite](https://user-images.githubusercontent.com/35696537/102383098-2cda9200-3f99-11eb-8536-7c0bc333d84e.PNG)
