### PR TITLE
"Forgot Password" error: Validates that the email exists in the database

### DIFF
--- a/applications/home/views.py
+++ b/applications/home/views.py
@@ -161,9 +161,9 @@ def forgot_password_page(request):
 		if users.get_user(request, email) is not None:
 			password_reset_code = users.add_user_to_password_reset(request, email)
 			users.send_password_reset_email(request, password_reset_code)
-			context["success_message"] = "You will receive an email with link to update the password!"
+			context["success_message"] = "You will receive an email with a link to update the password!"
 		else:
-			context["success_message"] = "You will receive an email with link to update the password!"
+			context["error_message"] = "No account is associated with that email address"
 		return render(request, 'forgot_password/index.html', context)  # Handle POST request to forgot password page.
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like PUT, UPDATE.

--- a/applications/home/views.py
+++ b/applications/home/views.py
@@ -156,13 +156,14 @@ def forgot_password_page(request):
 	if 'GET' == request.method:
 		return render(request, 'forgot_password/index.html', context)  # Handle GET request to forgot password page.
 	elif 'POST' == request.method:
-		password_reset_code = users.add_user_to_password_reset(request, email=request.POST.get('forgot_email', None))
+		email = request.POST.get('forgot_email', None)
 
-		if password_reset_code is not None:
+		if users.get_user(request, email) is not None:
+			password_reset_code = users.add_user_to_password_reset(request, email)
 			users.send_password_reset_email(request, password_reset_code)
 			context["success_message"] = "You will receive an email with link to update the password!"
 		else:
-			context["error_message"] = "You will receive an email with link to update the password!"
+			context["success_message"] = "You will receive an email with link to update the password!"
 		return render(request, 'forgot_password/index.html', context)  # Handle POST request to forgot password page.
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like PUT, UPDATE.


### PR DESCRIPTION
## Purpose
Avoids sending error page to users when an exception arises. The exception page would arise if an email was entered into the "forgot_password" was an email that didn't exist in the database.

Example:
Fixes #443 

## Approach
Error page: 
![image](https://user-images.githubusercontent.com/35696537/110252070-9becd480-7f51-11eb-9b18-22b22f3922a3.png)
We need to validate the user email before an exception arises where we are searching the database for an email that does not exist in it.
Now a green text box saying an email was sent is shown for all cases:
- validated email in the database
![image](https://user-images.githubusercontent.com/35696537/110252146-f9812100-7f51-11eb-9d18-89c25197d75a.png)

And a red text box saying no email exists is sent otherwise:
- blank email
- invalid email
- non-existent email in database
![image](https://user-images.githubusercontent.com/35696537/110395430-198d0f00-803c-11eb-9b49-c5f66d730507.png)




