### PR TITLE
Update dependency: Django 1.9.7 to 1.11.29

### DIFF
--- a/applications/graphs/views.py
+++ b/applications/graphs/views.py
@@ -15,7 +15,7 @@ from graphspace.wrappers import is_authenticated
 
 
 def upload_graph_page(request):
-	context = RequestContext(request, {})
+	context = {}
 
 	if request.method == 'POST':
 		try:
@@ -57,9 +57,8 @@ def graphs_page(request):
 		------
 	"""
 	if 'GET' == request.method:
-		context = RequestContext(request, {
-			"tags": request.GET.get('tags', '')
-		})
+		context = {"tags": request.GET.get('tags', '')}
+
 		return render(request, 'graphs/index.html', context)
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
@@ -94,18 +93,18 @@ def graph_page(request, graph_id):
 	graph_id : string
 		Unique ID of the graph. Required
 	"""
-	context = RequestContext(request, {})
+	context = {}
 	authorization.validate(request, permission='GRAPH_READ', graph_id=graph_id)
 
 	uid = request.session['uid'] if 'uid' in request.session else None
 
-	context.push({"graph": _get_graph(request, graph_id)})
-	context.push({"is_posted_by_public_user": 'public_user' in context["graph"]["owner_email"]})
-	context.push({"default_layout_id": str(context["graph"]['default_layout_id']) if context["graph"][
-		'default_layout_id'] else None})
+	context["graph"] = _get_graph(request, graph_id)
+	context["is_posted_by_public_user"] = 'public_user' in context["graph"]["owner_email"]
+	context["default_layout_id"] = str(context["graph"]['default_layout_id']) if context["graph"][
+		'default_layout_id'] else None
 
 	default_layout = graphs.get_layout_by_id(request, context["graph"]['default_layout_id']) if context["graph"][
-		                                                                                            'default_layout_id'] is not None else None
+		'default_layout_id'] is not None else None
 
 	if default_layout is not None and (default_layout.is_shared == 1 or default_layout.owner_email == uid) and request.GET.get(
 			'user_layout') is None and request.GET.get('auto_layout') is None:

--- a/applications/graphs/views.py
+++ b/applications/graphs/views.py
@@ -15,7 +15,7 @@ from graphspace.wrappers import is_authenticated
 
 
 def upload_graph_page(request):
-	context = {}
+	context = RequestContext(request, {})
 
 	if request.method == 'POST':
 		try:
@@ -57,8 +57,9 @@ def graphs_page(request):
 		------
 	"""
 	if 'GET' == request.method:
-		context = {"tags": request.GET.get('tags', '')}
-
+		context = RequestContext(request, {
+			"tags": request.GET.get('tags', '')
+		})
 		return render(request, 'graphs/index.html', context)
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
@@ -93,18 +94,18 @@ def graph_page(request, graph_id):
 	graph_id : string
 		Unique ID of the graph. Required
 	"""
-	context = {}
+	context = RequestContext(request, {})
 	authorization.validate(request, permission='GRAPH_READ', graph_id=graph_id)
 
 	uid = request.session['uid'] if 'uid' in request.session else None
 
-	context["graph"] = _get_graph(request, graph_id)
-	context["is_posted_by_public_user"] = 'public_user' in context["graph"]["owner_email"]
-	context["default_layout_id"] = str(context["graph"]['default_layout_id']) if context["graph"][
-		'default_layout_id'] else None
+	context.push({"graph": _get_graph(request, graph_id)})
+	context.push({"is_posted_by_public_user": 'public_user' in context["graph"]["owner_email"]})
+	context.push({"default_layout_id": str(context["graph"]['default_layout_id']) if context["graph"][
+		'default_layout_id'] else None})
 
 	default_layout = graphs.get_layout_by_id(request, context["graph"]['default_layout_id']) if context["graph"][
-		'default_layout_id'] is not None else None
+		                                                                                            'default_layout_id'] is not None else None
 
 	if default_layout is not None and (default_layout.is_shared == 1 or default_layout.owner_email == uid) and request.GET.get(
 			'user_layout') is None and request.GET.get('auto_layout') is None:

--- a/applications/graphs/views.py
+++ b/applications/graphs/views.py
@@ -30,9 +30,9 @@ def upload_graph_page(request):
 		except Exception as e:
 			context['Error'] = str(e)
 
-		return render(request, 'upload_graph/index.html', context)
+		return render(request, 'upload_graph/index.html', context.flatten())
 	else:
-		return render(request, 'upload_graph/index.html', context)
+		return render(request, 'upload_graph/index.html', context.flatten())
 
 
 def graphs_page(request):
@@ -60,7 +60,7 @@ def graphs_page(request):
 		context = RequestContext(request, {
 			"tags": request.GET.get('tags', '')
 		})
-		return render(request, 'graphs/index.html', context)
+		return render(request, 'graphs/index.html', context.flatten())
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
 
@@ -140,7 +140,7 @@ def graph_page(request, graph_id):
 		for group in context['groups']:
 			group['is_shared'] = 1 if group['id'] in shared_group_ids else 0
 
-	return render(request, 'graph/index.html', context)
+	return render(request, 'graph/index.html', context.flatten())
 
 
 '''

--- a/applications/home/views.py
+++ b/applications/home/views.py
@@ -31,7 +31,7 @@ def home_page(request):
 	------
 
 	"""
-	context = {}  # Checkout base.py file to see what context processors are being applied here.
+	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'home/index.html', context)  # Handle GET request to index page.
@@ -61,7 +61,7 @@ def features_page(request):
 	------
 
 	"""
-	context = {}  # Checkout base.py file to see what context processors are being applied here.
+	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'features/index.html', context)  # Handle GET request to index page.
@@ -91,7 +91,7 @@ def help_page(request):
 	------
 
 	"""
-	context = {}  # Checkout base.py file to see what context processors are being applied here.
+	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'help/index.html', context)  # Handle GET request to index page.
@@ -121,7 +121,7 @@ def about_us_page(request):
 	------
 
 	"""
-	context = {}  # Checkout base.py file to see what context processors are being applied here.
+	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'about_us/index.html', context)  # Handle GET request to index page.
@@ -151,7 +151,7 @@ def forgot_password_page(request):
 	------
 
 	"""
-	context = {}  # Checkout base.py file to see what context processors are being applied here.
+	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'forgot_password/index.html', context)  # Handle GET request to forgot password page.
@@ -190,7 +190,7 @@ def reset_password_page(request):
 	------
 
 	"""
-	context = {}  # Checkout base.py file to see what context processors are being applied here.
+	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		password_reset_code = users.get_password_reset_by_code(request, request.GET.get('code', None))

--- a/applications/home/views.py
+++ b/applications/home/views.py
@@ -34,7 +34,7 @@ def home_page(request):
 	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
-		return render(request, 'home/index.html', context)  # Handle GET request to index page.
+		return render(request, 'home/index.html', context.flatten())  # Handle GET request to index page.
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
 
@@ -64,7 +64,7 @@ def features_page(request):
 	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
-		return render(request, 'features/index.html', context)  # Handle GET request to index page.
+		return render(request, 'features/index.html', context.flatten())  # Handle GET request to index page.
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
 
@@ -94,7 +94,7 @@ def help_page(request):
 	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
-		return render(request, 'help/index.html', context)  # Handle GET request to index page.
+		return render(request, 'help/index.html', context.flatten())  # Handle GET request to index page.
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
 
@@ -124,7 +124,7 @@ def about_us_page(request):
 	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
-		return render(request, 'about_us/index.html', context)  # Handle GET request to index page.
+		return render(request, 'about_us/index.html', context.flatten())  # Handle GET request to index page.
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
 
@@ -154,7 +154,7 @@ def forgot_password_page(request):
 	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
-		return render(request, 'forgot_password/index.html', context)  # Handle GET request to forgot password page.
+		return render(request, 'forgot_password/index.html', context.flatten())  # Handle GET request to forgot password page.
 	elif 'POST' == request.method:
 		password_reset_code = users.add_user_to_password_reset(request, email=request.POST.get('forgot_email', None))
 
@@ -163,7 +163,7 @@ def forgot_password_page(request):
 			context["success_message"] = "You will receive an email with link to update the password!"
 		else:
 			context["error_message"] = "You will receive an email with link to update the password!"
-		return render(request, 'forgot_password/index.html', context)  # Handle POST request to forgot password page.
+		return render(request, 'forgot_password/index.html', context.flatten())  # Handle POST request to forgot password page.
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like PUT, UPDATE.
 
@@ -210,7 +210,7 @@ def reset_password_page(request):
 		else:
 			context['error_message'] = "This password reset link is outdated. Please try resetting your password again."
 
-		return render(request, 'reset_password/index.html', context)  # Handle POST request to forgot password page.
+		return render(request, 'reset_password/index.html', context.flatten())  # Handle POST request to forgot password page.
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like PUT, UPDATE.
 

--- a/applications/home/views.py
+++ b/applications/home/views.py
@@ -31,7 +31,7 @@ def home_page(request):
 	------
 
 	"""
-	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
+	context = {}  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'home/index.html', context)  # Handle GET request to index page.
@@ -61,7 +61,7 @@ def features_page(request):
 	------
 
 	"""
-	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
+	context = {}  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'features/index.html', context)  # Handle GET request to index page.
@@ -91,7 +91,7 @@ def help_page(request):
 	------
 
 	"""
-	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
+	context = {}  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'help/index.html', context)  # Handle GET request to index page.
@@ -121,7 +121,7 @@ def about_us_page(request):
 	------
 
 	"""
-	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
+	context = {}  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'about_us/index.html', context)  # Handle GET request to index page.
@@ -151,7 +151,7 @@ def forgot_password_page(request):
 	------
 
 	"""
-	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
+	context = {}  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		return render(request, 'forgot_password/index.html', context)  # Handle GET request to forgot password page.
@@ -190,7 +190,7 @@ def reset_password_page(request):
 	------
 
 	"""
-	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.
+	context = {}  # Checkout base.py file to see what context processors are being applied here.
 
 	if 'GET' == request.method:
 		password_reset_code = users.get_password_reset_by_code(request, request.GET.get('code', None))

--- a/applications/users/views.py
+++ b/applications/users/views.py
@@ -21,7 +21,7 @@ def groups_page(request):
 	"""
 	if 'GET' == request.method:
 		context = RequestContext(request, {})
-		return render(request, 'groups/index.html', context)
+		return render(request, 'groups/index.html', context.flatten())
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
 
@@ -43,7 +43,7 @@ def group_page(request, group_id):
 		context.push({
 			"group": _get_group(request, int(group_id)),
 		})
-		return render(request, 'group/index.html', context)
+		return render(request, 'group/index.html', context.flatten())
 	else:
 		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
 
@@ -69,7 +69,7 @@ def join_group_page(request, group_id):
 					"group": group,
 					"invite_code": request.GET.get('code', None)
 				})
-				return render(request, 'join_group/index.html', context)
+				return render(request, 'join_group/index.html', context.flatten())
 			else:
 				try:
 					users.add_group_member(request, group_id, member_email=request.session['uid'])
@@ -97,7 +97,7 @@ def join_group_page(request, group_id):
 					"group": group,
 					"invite_code": request.POST.get('code', None)
 				})
-				return render(request, 'join_group/index.html', context)
+				return render(request, 'join_group/index.html', context.flatten())
 		else:
 			return redirect('/')  # TODO: change it to signup page. Currently we dont have a signup link.
 	else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.8
 Babel==2.3.4
 decorator==4.0.10
-Django==1.9.7
+Django==1.11.29
 django-analytical==2.2.1
 django-braces==1.10.0
 django-cors-middleware==1.3.1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('requirements.txt') as reqs:
 
 setup(
     name = 'GraphSpace Server',
-    version = '1.3.0',
+    version = '1.2.0',
     url = 'http://graphspace.org',
     license = 'GNU GENERAL PUBLIC LICENSE',
     author = 'adb',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('requirements.txt') as reqs:
 
 setup(
     name = 'GraphSpace Server',
-    version = '1.2.0',
+    version = '1.3.0',
     url = 'http://graphspace.org',
     license = 'GNU GENERAL PUBLIC LICENSE',
     author = 'adb',

--- a/templates/graph/default_sidebar.html
+++ b/templates/graph/default_sidebar.html
@@ -53,11 +53,6 @@
                 <i class="fa fa-pencil-square-o fa-lg"></i> Use Layout <br> Editor
             </a>
         </li>
-        <li>
-            <a id="legendEditorBtn" class="btn sidebar-nav-pills" href="#legendEditor" data-target="#legendEditorSideBar">
-                <i class="fa fa-pencil-square-o fa-lg"></i> Use Legend <br> Editor
-            </a>
-        </li>
     {% endif %}
 
     {% if uid and uid == graph.owner_email %}


### PR DESCRIPTION
## Purpose
Updating Django from 1.9.7 to 1.11.29 required changing the way that render method is called in views.py. In Django 1.10.0, contexts cannot be passed as an argument to render method but rather a dictionary should be passed instead.
Quote from [1.10 release notes](https://docs.djangoproject.com/en/3.1/releases/1.10/):
"Django template objects returned by get_template() and select_template() no longer accept a Context in their render() method."

This solution proposed is to call the context object's flatten method when it is passed to the render method. The flatten method returns the dictionary of the context Object. Since the RequestContext object isn't much more than a wrapper for the dictionary, it doesn't seem that any other parts of the context object are being used in render() anyway.
This change affects:
- graphs/views.py
- home/view.py
- users/views.py

Example:
Fixes #442  .

## Approach
The flatten method is called to pass the dictionary of the context to render method:
```
	context = RequestContext(request)  # Checkout base.py file to see what context processors are being applied here.

	if 'GET' == request.method:
		return render(request, 'home/index.html', context.flatten())  # Handle GET request to index page.
	else:
		raise MethodNotAllowed(request)  # Handle other type of request methods like POST, PUT, UPDATE.
```

#### Open Questions and Pre-Merge TODOs
This merge will have to be carefully merged alongside #444 

## Learning
Django 1.10.0 deprecates passing RequestContext to render method.


