### PR TITLE
Update pygments dependency to 2.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ oauthlib==1.1.2
 poster==0.8.1
 psycopg2==2.6.2
 py-bcrypt==0.4
-Pygments==2.1.3
+Pygments==2.5.2
 pytz==2016.4
 requests==2.20.0
 six==1.10.0


### PR DESCRIPTION
## Purpose
Update Pygments dependency to 2.5.2

Note: this is the last supported version for python 2.7. Most likely will not be updating this dependency any further.

**Changelog**:
https://pygments.org/docs/changelog/



