### PR TITLE
Fix Export Button UI bug

### DIFF
--- a/templates/graph/index.html
+++ b/templates/graph/index.html
@@ -218,7 +218,7 @@
                         <i class="fa fa-share-alt fa-lg"></i> Share
                     </a>
                 {% endif %}
-                <div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 20000">
+                <div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 1001">
                     <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown"
                             aria-haspopup="true" aria-expanded="false">
                         <i class="fa fa-download fa-lg"></i> Export <span class="caret"></span>


### PR DESCRIPTION
This is the same PR fix as #346 but I created a new PR because the outdated PR had a deleted repo.

This fixes #343 concerning UI of Export button.
Bug : Export button is always at the top because of an unusually high z-index value of 20000. The problem is that when the user wants to sign-out the export button hides the sign-out drop-down menu. Also, while scrolling down, export button goes above the main header of the page.
I believe the z-index was set to make sure Export Dropdown menu does not get hidden by the Graph Visualisation Canvas.

Resolution : Setting z-index to 1001 fixes the the issue.

current div :
`<div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 20000">`
proposed change :
`<div class="btn-group pull-right" style="margin-right: 1em !important; z-index: 1001">`

**The Bug :** 

![bug 343](https://user-images.githubusercontent.com/4581090/35942274-014e63be-0c4d-11e8-9b51-8d71ae3684eb.gif)


**Fixed UI :**

![fixed 343](https://user-images.githubusercontent.com/4581090/35942532-d8a6cfd6-0c4d-11e8-8235-f031696bcf25.gif)

