### PR TITLE
Add sections about hosting GraphSpace to About Us page e#440

### DIFF
--- a/docs/Hosting_Graphspace.md
+++ b/docs/Hosting_Graphspace.md
@@ -1,0 +1,13 @@
+# Hosting a GraphSpace Server
+
+## How to deploy the latest Github code changes on GraphSpace server? ##
+
+Here are the steps for deploying GraphSpace. It is recommended to download the [latest release](https://github.com/Murali-group/GraphSpace/releases/latest). Otherwise you can download the latest code directly from the [master branch](https://github.com/Murali-group/GraphSpace).
+Then follow the steps to [run GraphSpace on Apache](https://github.com/Murali-group/GraphSpace#running-graphspace-on-apache). These include steps to install the correct version of python, setup postgreSQL, virtualenv, bower, ElasticSearch, etc.
+
+>**Note**:
+>Be careful when running alembic migration scripts if you plan to continually update a deployment of GraphSpace. Understand how to use [alembic](https://alembic.sqlalchemy.org/en/latest/tutorial.html#) and alembic commands. Migrations are not needed if you are creating the database for the first time.
+
+***Useful Links***
+- [How to configure Apache to run Django website](https://docs.djangoproject.com/en/3.1/howto/deployment/wsgi/modwsgi/#basic-configuration)
+- [How to use Django with Apache and mod-wsgi](https://docs.djangoproject.com/en/3.1/howto/deployment/wsgi/modwsgi/)

--- a/docs/Hosting_Graphspace.md
+++ b/docs/Hosting_Graphspace.md
@@ -1,4 +1,4 @@
-# Hosting a GraphSpace Server
+# Hosting GraphSpace
 
 ## How to deploy the latest Github code changes on GraphSpace server? ##
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,4 +24,5 @@ GraphSpace 2.0 User Manual
    Editing_Layouts
    Organizing_Graphs_Using_Tags
    Programmers_Guide
+   Hosting_Graphspace
    Release_Notes


### PR DESCRIPTION
## Purpose
Fixes #440 

Adds a new section to the about us section on how to host GraphSpace.
