### PR TITLE
API Update graph properly update Title/tags

### DIFF
--- a/applications/graphs/controllers.py
+++ b/applications/graphs/controllers.py
@@ -263,7 +263,7 @@ def update_graph(request, graph_id, name=None, is_public=None, graph_json=None, 
 
 		graph['graph_json'] = json.dumps(G.get_graph_json())
 
-		body_data.update(map_attributes(G.get_graph_json))
+		body_data.update(map_attributes(G.get_graph_json()))
 
 	updated_graph = db.update_graph(request.db_session, id=graph_id, updated_graph=graph)
 	# If any information in Elasticsearch was changed


### PR DESCRIPTION
## Purpose
Fixes #453 

The update_graph method was incorrectly updating ElasticSearch with the new JSON contents of an updated graph from API requests. This was a result of a typo in a previous Pull request where the method was being passed as an instance itself instead of calling the method and passing the return value.

