### PR TITLE
Visualization improvement for selecting parent node

### DIFF
--- a/static/js/graphs_page.js
+++ b/static/js/graphs_page.js
@@ -1660,7 +1660,7 @@ var graphPage = {
     nodeSelector: {
       init: function () {
         var colors = _.uniq( _.map( graphPage.cyGraph.nodes(), function ( node ) {
-            //If the ode is a parent node, do not include the color of the parent node to the color option
+            //If the node is a parent node, do not include the color of the parent node to the color option
             if (parent_nodes.indexOf(node.data().id) == -1)
             {
                 return node.style('background-color');
@@ -1668,6 +1668,7 @@ var graphPage = {
         } ) );
         $( '#selectColors' ).html( '' );
         _.each( colors, function ( color ) {
+            //We only set the color of nodes that aren't parent nodes
             if (color != null)
             {
                 $('#selectColors').append(


### PR DESCRIPTION
From Original PR (#313 ) 
merged branch to keep up to date with master:

Fixes #285 

From issue #285, since selecting parents node by shapes and color behaves bad visualization the child node, select by shapes and color button now only works on the child node. During initialize the graph, the parent nodes are selected and pushed into parent_nodes array. The options of select by shapes and color are also edited into only show options of child nodes' shapes and color.

This design disables the automatic selection for parent node by shape and color. The discussion will be further needed for design perspective.

BEFORE
![2](https://user-images.githubusercontent.com/9061404/29283652-a636d642-80f5-11e7-82d2-d22f5e7006ba.png)

AFTER
![1](https://user-images.githubusercontent.com/9061404/29283669-afcb2ae6-80f5-11e7-9a77-882cf7ea9f5a.png)